### PR TITLE
Add new BeautifulSoup and JSDOM examples with project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [rpa-example](./typescript-examples/rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./typescript-examples/rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
 | [e-commerece-shopify](./typescript-examples/e-commerece-shopify/) | Shopify store product scraper |
+| [jsdom-example](./typescript-examples/jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 
 ## Python Examples
 
@@ -17,3 +18,4 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [rpa-example](./python-examples/rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./python-examples/rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
 | [e-commerece-shopify](./python-examples/e-commerece-shopify/) | Shopify store product scraper |
+| [bs4-example](./python-examples/bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |

--- a/python-examples/README.md
+++ b/python-examples/README.md
@@ -8,3 +8,4 @@ Intuned sample projects in Python.
 | [rpa-example](./rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
 | [e-commerece-shopify](./e-commerece-shopify/) | Shopify store product scraper |
+| [bs4-example](./bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |

--- a/python-examples/bs4-example/.env.example
+++ b/python-examples/bs4-example/.env.example
@@ -1,0 +1,1 @@
+INTUNED_API_KEY=your_api_key_here

--- a/python-examples/bs4-example/.gitignore
+++ b/python-examples/bs4-example/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/python-examples/bs4-example/Intuned.jsonc
+++ b/python-examples/bs4-example/Intuned.jsonc
@@ -1,0 +1,23 @@
+// For more information, see our Intuned settings reference
+// https://docs.intunedhq.com/docs/05-references/intuned-json
+{
+  "projectName": "beautifulSoup-example",
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "defaultRunPlaygroundInput": {
+      "api": "list",
+      "parameters": {
+        "url": "https://www.example.com"
+      }
+    }
+  }
+}

--- a/python-examples/bs4-example/README.md
+++ b/python-examples/bs4-example/README.md
@@ -1,6 +1,6 @@
-# book-consultations Intuned project
+# bs4-example Intuned project
 
-Booking automation to book a consultation with a consultant and list the consultations
+E-commerce scraper using BeautifulSoup for HTML parsing to extract product listings and details with pagination support.
 
 ## Getting Started
 
@@ -42,15 +42,17 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 The project structure is as follows:
 ```
 /
-├── apis/                     # Your API endpoints 
-│   └── ...   
-├── auth-sessions/            # Auth session related APIs
-│   ├── check.py           # API to check if the auth session is still valid
-│   └── create.py          # API to create/recreate the auth session programmatically
-├── auth-sessions-instances/  # Auth session instances created and used by the CLI
-│   └── ...
-└── intuned.json              # Intuned project configuration file
+├── api/                      # Your API endpoints 
+│   ├── list.py               # API to scrape product listings with pagination
+│   └── details.py            # API to extract detailed product information
+└── Intuned.jsonc             # Intuned project configuration file
 ```
+
+### How It Works
+
+1. **list.py** - Navigates to the listing page, extracts product title, price, and URL using BeautifulSoup, follows pagination links, and calls `extend_payload` to send each product to the details API.
+
+2. **details.py** - Receives product data from list API, navigates to the product page, and extracts additional details (description, SKU, category, sizes, colors, images).
 
 
 ## `Intuned.json` Reference
@@ -124,4 +126,3 @@ The project structure is as follows:
   "region": "us"
 }
 ```
-  

--- a/python-examples/bs4-example/README.md
+++ b/python-examples/bs4-example/README.md
@@ -1,0 +1,127 @@
+# book-consultations Intuned project
+
+Booking automation to book a consultation with a consultant and list the consultations
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+uv sync
+```
+
+After installing dependencies, `intuned` command should be available in your environment.
+
+### Run an API
+```bash
+uv run intuned run api <api-name> <parameters>
+```
+
+### Deploy project
+```bash
+uv run intuned deploy
+```
+
+
+
+
+### `intuned-browser`: Intuned Browser SDK
+
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+
+
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── apis/                     # Your API endpoints 
+│   └── ...   
+├── auth-sessions/            # Auth session related APIs
+│   ├── check.py           # API to check if the auth session is still valid
+│   └── create.py          # API to create/recreate the auth session programmatically
+├── auth-sessions-instances/  # Auth session instances created and used by the CLI
+│   └── ...
+└── intuned.json              # Intuned project configuration file
+```
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // Your Intuned workspace ID. 
+  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
+  "workspaceId": "your_workspace_id",
+
+  // The name of your Intuned project. 
+  // Optional - If not provided here, it must be supplied via the command line when deploying.
+  "projectName": "your_project_name",
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
+    // A number of machines equal to this will be allocated to handle API requests.
+    // Not applicable if api access is disabled.
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project. This is applicable for both API requests and jobs.
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  }
+
+  // Auth session settings
+  "authSessions": {
+    // Whether auth sessions are enabled for this project.
+    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
+    "enabled": true,
+
+    // Whether to save Playwright traces for auth session runs.
+    "saveTraces": false,
+
+    // The type of auth session to use.
+    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
+    // "MANUAL" type uses a recorder to manually create the auth session.
+    "type": "API",
+    
+
+    // Recorder start URL for the recorder to navigate to when creating the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "startUrl": "https://example.com/login",
+
+    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "finishUrl": "https://example.com/dashboard",
+
+    // Recorder browser mode
+    // "fullscreen": Launches the browser in fullscreen mode.
+    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
+    // Only applicable for "MANUAL" type.
+    "browserMode": "fullscreen"
+  }
+  
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
+    // This is required for projects that use auth sessions.
+    "enabled": true
+  },
+
+  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
+  "headful": false,
+
+  // The region where your Intuned project is hosted.
+  // For a list of available regions, contact support or refer to the documentation.
+  // Optional - Default: "us"
+  "region": "us"
+}
+```
+  

--- a/python-examples/bs4-example/README.md
+++ b/python-examples/bs4-example/README.md
@@ -45,7 +45,10 @@ The project structure is as follows:
 ├── api/                      # Your API endpoints 
 │   ├── list.py               # API to scrape product listings with pagination
 │   └── details.py            # API to extract detailed product information
-└── Intuned.jsonc             # Intuned project configuration file
+├── utils/
+│   └── types_and_schemas.py  # Pydantic models for type validation
+├── Intuned.jsonc             # Intuned project configuration file
+└── pyproject.toml            # Python project dependencies
 ```
 
 ### How It Works

--- a/python-examples/bs4-example/__testParameters/details.json
+++ b/python-examples/bs4-example/__testParameters/details.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "Abominable Hoodie",
+    "value": "{\n  \"title\": \"Abominable Hoodie\",\n  \"price\": \"$69.00\",\n  \"details_url\": \"https://www.scrapingcourse.com/ecommerce/product/abominable-hoodie/\"\n}",
+    "lastUsed": true,
+    "id": "d4e5f6a7-b8c9-0123-def0-123456789abc"
+  },
+  {
+    "name": "Chaz Kangeroo Hoodie",
+    "value": "{\n  \"title\": \"Chaz Kangeroo Hoodie\",\n  \"price\": \"$52.00\",\n  \"details_url\": \"https://www.scrapingcourse.com/ecommerce/product/chaz-kangeroo-hoodie/\"\n}",
+    "lastUsed": false,
+    "id": "e5f6a7b8-c9d0-1234-ef01-23456789abcd"
+  }
+]
+

--- a/python-examples/bs4-example/__testParameters/list.json
+++ b/python-examples/bs4-example/__testParameters/list.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Default test - 2 pages",
+    "value": "{\n  \"url\": \"https://www.scrapingcourse.com/ecommerce/\",\n  \"max_pages\": 2\n}",
+    "lastUsed": true,
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  },
+  {
+    "name": "Full scrape - 10 pages",
+    "value": "{\n  \"url\": \"https://www.scrapingcourse.com/ecommerce/\",\n  \"max_pages\": 10\n}",
+    "lastUsed": false,
+    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+  },
+  {
+    "name": "Single page only",
+    "value": "{\n  \"url\": \"https://www.scrapingcourse.com/ecommerce/\",\n  \"max_pages\": 1\n}",
+    "lastUsed": false,
+    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012"
+  }
+]
+

--- a/python-examples/bs4-example/api/details.py
+++ b/python-examples/bs4-example/api/details.py
@@ -1,0 +1,121 @@
+from playwright.async_api import Page, BrowserContext
+from typing import TypedDict, List
+from bs4 import BeautifulSoup
+from intuned_browser import go_to_url
+
+
+class Params(TypedDict):
+    title: str
+    price: str
+    details_url: str
+
+
+class ProductDetails(TypedDict):
+    title: str
+    price: str
+    source_url: str
+    description: str
+    sku: str
+    category: str
+    sizes: List[str]
+    colors: List[str]
+    images: List[str]
+
+
+def extract_product_details(html: str, params: Params) -> ProductDetails:
+    """
+    Extracts detailed product information from the page HTML using BeautifulSoup.
+    Replace selectors with appropriate ones for your target site.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Extract description - replace selector as needed
+    description_element = soup.select_one("#tab-description p")
+    description = (
+        description_element.get_text(strip=True) if description_element else ""
+    )
+
+    # Extract SKU - replace selector as needed
+    sku_element = soup.select_one(".sku")
+    sku = sku_element.get_text(strip=True) if sku_element else ""
+
+    # Extract category - replace selector as needed
+    category_element = soup.select_one(".posted_in a")
+    category = category_element.get_text(strip=True) if category_element else ""
+
+    # Extract sizes from select options - replace selector as needed
+    size_options = soup.select("#size option")
+    sizes = [
+        opt.get_text(strip=True)
+        for opt in size_options
+        if opt.get("value") and opt.get("value") != ""
+    ]
+
+    # Extract colors from select options - replace selector as needed
+    color_options = soup.select("#color option")
+    colors = [
+        opt.get_text(strip=True)
+        for opt in color_options
+        if opt.get("value") and opt.get("value") != ""
+    ]
+
+    # Extract product images - replace selector as needed
+    image_elements = soup.select(".woocommerce-product-gallery__image img")
+    images = [img.get("src", "") for img in image_elements if img.get("src")]
+
+    return {
+        "title": params["title"],
+        "price": params["price"],
+        "source_url": params["details_url"],
+        "description": description,
+        "sku": sku,
+        "category": category,
+        "sizes": sizes,
+        "colors": colors,
+        "images": images,
+    }
+
+
+async def automation(
+    page: Page,
+    params: Params,
+    context: BrowserContext | None = None,
+    **_kwargs,
+):
+    """
+    Scrapes product details from a product page using BeautifulSoup.
+    This API is called via extend_payload from the list API.
+
+    Expected params (from list.py extend_payload):
+    {
+        "title": "Product Name",
+        "price": "$19.99",
+        "details_url": "https://www.scrapingcourse.com/ecommerce/product/example"
+    }
+
+    This function:
+    1. Navigates to the product details page
+    2. Extracts additional product information using BeautifulSoup
+    3. Returns complete product details
+    """
+    # Validate required params
+    if not params.get("details_url"):
+        raise ValueError("details_url is required in params")
+
+    details_url = params["details_url"]
+    print(f"Scraping product details from: {details_url}")
+
+    # Navigate to the product page
+    await go_to_url(page, details_url)
+
+    # Wait for the product content to load - replace selector as needed
+    await page.wait_for_selector(".product")
+
+    # Get the page HTML
+    html = await page.content()
+
+    # Extract product details using BeautifulSoup
+    product_details = extract_product_details(html, params)
+
+    print(f"Successfully scraped details for: {product_details['title']}")
+    return product_details

--- a/python-examples/bs4-example/api/list.py
+++ b/python-examples/bs4-example/api/list.py
@@ -1,19 +1,9 @@
 from playwright.async_api import Page, BrowserContext
-from typing import TypedDict, List
+from typing import List
 from bs4 import BeautifulSoup
 from intuned_browser import go_to_url
 from runtime_helpers import extend_payload
-
-
-class Params(TypedDict):
-    url: str  # The URL to scrape (e.g.: https://www.scrapingcourse.com/ecommerce/)
-    max_pages: int | None  # Maximum number of pages to scrape (default: 10)
-
-
-class Product(TypedDict):
-    title: str
-    price: str
-    details_url: str
+from utils.types_and_schemas import ListParams, Product
 
 
 def extract_products(html: str) -> List[Product]:
@@ -42,11 +32,11 @@ def extract_products(html: str) -> List[Product]:
 
         if title and details_url:
             products.append(
-                {
-                    "title": title,
-                    "price": price,
-                    "details_url": details_url,
-                }
+                Product(
+                    title=title,
+                    price=price,
+                    details_url=details_url,
+                )
             )
 
     return products
@@ -70,7 +60,7 @@ def get_next_page_url(html: str) -> str | None:
 
 async def automation(
     page: Page,
-    params: Params,
+    params: ListParams,
     context: BrowserContext | None = None,
     **_kwargs,
 ):
@@ -90,11 +80,12 @@ async def automation(
     3. Follows pagination links to scrape multiple pages
     4. Returns all products found
     """
+    params = ListParams(**params)
     # Set default values
-    url = params["url"]
+    url = params.url
     if not url:
         raise ValueError("url is required in params")
-    max_pages = params["max_pages"] or 10
+    max_pages = params.max_pages
 
     print(f"Starting scrape from: {url}")
     print(f"Max pages: {max_pages}")

--- a/python-examples/bs4-example/api/list.py
+++ b/python-examples/bs4-example/api/list.py
@@ -1,0 +1,140 @@
+from playwright.async_api import Page, BrowserContext
+from typing import TypedDict, List
+from bs4 import BeautifulSoup
+from intuned_browser import go_to_url
+from runtime_helpers import extend_payload
+
+
+class Params(TypedDict):
+    url: str  # The URL to scrape (e.g.: https://www.scrapingcourse.com/ecommerce/)
+    max_pages: int | None  # Maximum number of pages to scrape (default: 10)
+
+
+class Product(TypedDict):
+    title: str
+    price: str
+    details_url: str
+
+
+def extract_products(html: str) -> List[Product]:
+    """
+    Extracts product info from the page HTML using BeautifulSoup.
+    Replace selectors with appropriate ones for your target site.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    products: List[Product] = []
+
+    # Find all product items - replace selector as needed
+    product_elements = soup.select("li.product")
+
+    for product in product_elements:
+        # Extract title - replace selector as needed
+        title_element = product.select_one("h2.woocommerce-loop-product__title")
+        title = title_element.get_text(strip=True) if title_element else ""
+
+        # Extract price - replace selector as needed
+        price_element = product.select_one("span.woocommerce-Price-amount")
+        price = price_element.get_text(strip=True) if price_element else ""
+
+        # Extract details URL - replace selector as needed
+        link_element = product.select_one("a.woocommerce-LoopProduct-link")
+        details_url = link_element.get("href", "") if link_element else ""
+
+        if title and details_url:
+            products.append(
+                {
+                    "title": title,
+                    "price": price,
+                    "details_url": details_url,
+                }
+            )
+
+    return products
+
+
+def get_next_page_url(html: str) -> str | None:
+    """
+    Extracts the next page URL from pagination.
+    Returns None if there is no next page.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Find the next page link - replace selector as needed
+    next_link = soup.select_one("a.next.page-numbers")
+
+    if next_link:
+        return next_link.get("href")
+
+    return None
+
+
+async def automation(
+    page: Page,
+    params: Params,
+    context: BrowserContext | None = None,
+    **_kwargs,
+):
+    """
+    Scrapes product listings from an e-commerce site using BeautifulSoup.
+    Handles pagination by following "Next" page links.
+
+    Example params:
+    {
+        "url": "https://www.scrapingcourse.com/ecommerce/",
+        "max_pages": 5
+    }
+
+    This function:
+    1. Navigates to the listing page
+    2. Extracts product data using BeautifulSoup
+    3. Follows pagination links to scrape multiple pages
+    4. Returns all products found
+    """
+    # Set default values
+    url = params["url"]
+    if not url:
+        raise ValueError("url is required in params")
+    max_pages = params["max_pages"] or 10
+
+    print(f"Starting scrape from: {url}")
+    print(f"Max pages: {max_pages}")
+
+    all_products: List[Product] = []
+    current_url: str | None = url
+    current_page = 1
+
+    while current_url and current_page <= max_pages:
+        print(f"Scraping page {current_page}: {current_url}")
+
+        # Navigate to the page
+        await go_to_url(page, current_url)
+
+        # Wait for products to load - replace selector as needed
+        await page.wait_for_selector("li.product")
+
+        # Get the page HTML
+        html = await page.content()
+
+        # Extract products using BeautifulSoup
+        products = extract_products(html)
+        all_products.extend(products)
+
+        print(f"Found {len(products)} products on page {current_page}")
+
+        # Get next page URL
+        current_url = get_next_page_url(html)
+        current_page += 1
+
+    print(f"Total products scraped: {len(all_products)}")
+    for product in all_products:
+        extend_payload(
+            {
+                "api": "details",
+                "parameters": product,
+            }
+        )
+    return {
+        "products": all_products,
+        "count": len(all_products),
+        "pages_scraped": current_page - 1,
+    }

--- a/python-examples/bs4-example/pyproject.toml
+++ b/python-examples/bs4-example/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "intuned-runtime==1.3.11",
     "intuned-browser==0.1.9",
     "beautifulsoup4==4.14.3",
+    "pydantic>=2.12.5",
 ]
 
 [tool.uv]

--- a/python-examples/bs4-example/pyproject.toml
+++ b/python-examples/bs4-example/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "beautifulSoup-example"
+version = "0.0.1"
+description = "BeautifulSoup example to scrape a website and extract data"
+authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
+requires-python = ">=3.12,<3.13"
+readme = "README.md"
+keywords = [
+    "Python",
+    "intuned-browser-sdk",
+]
+dependencies = [
+    "playwright==1.56",
+    "intuned-runtime==1.3.11",
+    "intuned-browser==0.1.9",
+    "beautifulsoup4==4.14.3",
+]
+
+[tool.uv]
+package = false

--- a/python-examples/bs4-example/utils/types_and_schemas.py
+++ b/python-examples/bs4-example/utils/types_and_schemas.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel, Field
+from typing import List
+
+
+class ListParams(BaseModel):
+    url: str = Field(..., description="The URL to scrape")
+    max_pages: int = Field(
+        default=10, description="The maximum number of pages to scrape"
+    )
+
+
+class DetailsParams(BaseModel):
+    details_url: str = Field(..., description="The URL to the product details")
+    title: str = Field(..., description="The title of the product")
+    price: str | None = Field(default=None, description="The price of the product")
+
+
+class Product(BaseModel):
+    title: str = Field(..., description="The title of the product")
+    price: str | None = Field(default=None, description="The price of the product")
+    details_url: str = Field(..., description="The URL to the product details")
+
+
+class ProductDetails(BaseModel):
+    title: str = Field(..., description="The title of the product")
+    price: str | None = Field(default=None, description="The price of the product")
+    details_url: str = Field(..., description="The URL to the product details")
+    description: str | None = Field(
+        default=None, description="The description of the product"
+    )
+    sku: str | None = Field(default=None, description="The SKU of the product")
+    category: str | None = Field(
+        default=None, description="The category of the product"
+    )
+    sizes: List[str] | None = Field(
+        default_factory=list, description="The sizes of the product"
+    )
+    colors: List[str] | None = Field(
+        default_factory=list, description="The colors of the product"
+    )
+    images: List[str] | None = Field(
+        default_factory=list, description="The images of the product"
+    )

--- a/typescript-examples/README.md
+++ b/typescript-examples/README.md
@@ -8,4 +8,5 @@ Intuned sample projects in TypeScript.
 | [rpa-example](./rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
 | [e-commerece-shopify](./e-commerece-shopify/) | Shopify store product scraper |
+| [jsdom-example](./jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 

--- a/typescript-examples/jsdom-example/.env.example
+++ b/typescript-examples/jsdom-example/.env.example
@@ -1,0 +1,1 @@
+INTUNED_API_KEY=your_api_key_here

--- a/typescript-examples/jsdom-example/.gitignore
+++ b/typescript-examples/jsdom-example/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/typescript-examples/jsdom-example/Intuned.jsonc
+++ b/typescript-examples/jsdom-example/Intuned.jsonc
@@ -1,7 +1,7 @@
 // For more information, see our Intuned settings reference
 // https://docs.intunedhq.com/docs/05-references/intuned-json
 {
-  "projectName": "book-consultations",
+  "projectName": "jsdom-example",
   "apiAccess": {
     "enabled": true
   },
@@ -14,14 +14,9 @@
   },
   "metadata": {
     "defaultRunPlaygroundInput": {
-      "api": "book-consultations",
+      "api": "jsdom-example",
       "parameters": {
-        "name": "Foo Bar",
-        "email": "foo@bar.com",
-        "phone": "1234567890",
-        "date": "2026-11-19",
-        "time": "10:00 AM",
-        "topic": "other"
+        "url": "https://www.scrapingcourse.com/ecommerce/"
       }
     }
   }

--- a/typescript-examples/jsdom-example/Intuned.jsonc
+++ b/typescript-examples/jsdom-example/Intuned.jsonc
@@ -1,0 +1,28 @@
+// For more information, see our Intuned settings reference
+// https://docs.intunedhq.com/docs/05-references/intuned-json
+{
+  "projectName": "book-consultations",
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "defaultRunPlaygroundInput": {
+      "api": "book-consultations",
+      "parameters": {
+        "name": "Foo Bar",
+        "email": "foo@bar.com",
+        "phone": "1234567890",
+        "date": "2026-11-19",
+        "time": "10:00 AM",
+        "topic": "other"
+      }
+    }
+  }
+}

--- a/typescript-examples/jsdom-example/README.md
+++ b/typescript-examples/jsdom-example/README.md
@@ -1,6 +1,6 @@
-# book-consultations Intuned project
+# jsdom-example Intuned project
 
-Booking automation to book a consultation with a consultant and list the consultations
+E-commerce scraper using JSDOM for HTML parsing to extract product listings and details with pagination support.
 
 ## Getting Started
 
@@ -46,6 +46,9 @@ yarn intuned deploy
 
 
 
+### `@intuned/browser`: Intuned Browser SDK
+
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
 
 
 
@@ -54,15 +57,19 @@ yarn intuned deploy
 The project structure is as follows:
 ```
 /
-├── apis/                     # Your API endpoints 
-│   └── ...   
-├── auth-sessions/            # Auth session related APIs
-│   ├── check.ts           # API to check if the auth session is still valid
-│   └── create.ts          # API to create/recreate the auth session programmatically
-├── auth-sessions-instances/  # Auth session instances created and used by the CLI
-│   └── ...
-└── intuned.json              # Intuned project configuration file
+├── api/                      # Your API endpoints 
+│   ├── list.ts               # API to scrape product listings with pagination
+│   └── details.ts            # API to extract detailed product information
+├── utils/
+│   └── typesAndSchemas.ts    # Zod schemas and TypeScript interfaces
+└── Intuned.jsonc             # Intuned project configuration file
 ```
+
+### How It Works
+
+1. **list.ts** - Navigates to the listing page, extracts product title, price, and URL using JSDOM, follows pagination links, and calls `extendPayload` to send each product to the details API.
+
+2. **details.ts** - Receives product data from list API, navigates to the product page, and extracts additional details (description, SKU, category, sizes, colors, images).
 
 
 ## `Intuned.json` Reference
@@ -136,4 +143,3 @@ The project structure is as follows:
   "region": "us"
 }
 ```
-  

--- a/typescript-examples/jsdom-example/README.md
+++ b/typescript-examples/jsdom-example/README.md
@@ -1,0 +1,139 @@
+# book-consultations Intuned project
+
+Booking automation to book a consultation with a consultant and list the consultations
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# npm
+npm install
+
+# yarn
+yarn
+```
+
+> **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
+
+
+### Run an API
+
+```bash
+# npm
+npm run intuned run api <api-name> <parameters>
+
+# yarn
+yarn intuned run api <api-name> <parameters>
+```
+
+### Deploy project
+```bash
+# npm
+npm run intuned deploy
+
+# yarn
+yarn intuned deploy
+
+```
+
+
+
+
+
+
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── apis/                     # Your API endpoints 
+│   └── ...   
+├── auth-sessions/            # Auth session related APIs
+│   ├── check.ts           # API to check if the auth session is still valid
+│   └── create.ts          # API to create/recreate the auth session programmatically
+├── auth-sessions-instances/  # Auth session instances created and used by the CLI
+│   └── ...
+└── intuned.json              # Intuned project configuration file
+```
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // Your Intuned workspace ID. 
+  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
+  "workspaceId": "your_workspace_id",
+
+  // The name of your Intuned project. 
+  // Optional - If not provided here, it must be supplied via the command line when deploying.
+  "projectName": "your_project_name",
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
+    // A number of machines equal to this will be allocated to handle API requests.
+    // Not applicable if api access is disabled.
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project. This is applicable for both API requests and jobs.
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  }
+
+  // Auth session settings
+  "authSessions": {
+    // Whether auth sessions are enabled for this project.
+    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
+    "enabled": true,
+
+    // Whether to save Playwright traces for auth session runs.
+    "saveTraces": false,
+
+    // The type of auth session to use.
+    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
+    // "MANUAL" type uses a recorder to manually create the auth session.
+    "type": "API",
+    
+
+    // Recorder start URL for the recorder to navigate to when creating the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "startUrl": "https://example.com/login",
+
+    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "finishUrl": "https://example.com/dashboard",
+
+    // Recorder browser mode
+    // "fullscreen": Launches the browser in fullscreen mode.
+    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
+    // Only applicable for "MANUAL" type.
+    "browserMode": "fullscreen"
+  }
+  
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
+    // This is required for projects that use auth sessions.
+    "enabled": true
+  },
+
+  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
+  "headful": false,
+
+  // The region where your Intuned project is hosted.
+  // For a list of available regions, contact support or refer to the documentation.
+  // Optional - Default: "us"
+  "region": "us"
+}
+```
+  

--- a/typescript-examples/jsdom-example/README.md
+++ b/typescript-examples/jsdom-example/README.md
@@ -62,6 +62,7 @@ The project structure is as follows:
 │   └── details.ts            # API to extract detailed product information
 ├── utils/
 │   └── typesAndSchemas.ts    # Zod schemas and TypeScript interfaces
+├── package.json              # Typescript project dependencies
 └── Intuned.jsonc             # Intuned project configuration file
 ```
 

--- a/typescript-examples/jsdom-example/__testParameters/details.json
+++ b/typescript-examples/jsdom-example/__testParameters/details.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Abominable Hoodie",
+    "value": "{\n  \"title\": \"Abominable Hoodie\",\n  \"price\": \"$69.00\",\n  \"detailsUrl\": \"https://www.scrapingcourse.com/ecommerce/product/abominable-hoodie/\"\n}",
+    "lastUsed": true,
+    "id": "c9d0e1f2-a3b4-5678-2345-6789abcdef01"
+  },
+  {
+    "name": "Chaz Kangeroo Hoodie",
+    "value": "{\n  \"title\": \"Chaz Kangeroo Hoodie\",\n  \"price\": \"$52.00\",\n  \"detailsUrl\": \"https://www.scrapingcourse.com/ecommerce/product/chaz-kangeroo-hoodie/\"\n}",
+    "lastUsed": false,
+    "id": "d0e1f2a3-b4c5-6789-3456-789abcdef012"
+  }
+]

--- a/typescript-examples/jsdom-example/__testParameters/list.json
+++ b/typescript-examples/jsdom-example/__testParameters/list.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Default test - 2 pages",
+    "value": "{\n  \"url\": \"https://www.scrapingcourse.com/ecommerce/\",\n  \"maxPages\": 2\n}",
+    "lastUsed": true,
+    "id": "f6a7b8c9-d0e1-2345-f012-3456789abcde"
+  },
+  {
+    "name": "Full scrape - 10 pages",
+    "value": "{\n  \"url\": \"https://www.scrapingcourse.com/ecommerce/\",\n  \"maxPages\": 10\n}",
+    "lastUsed": false,
+    "id": "a7b8c9d0-e1f2-3456-0123-456789abcdef"
+  },
+  {
+    "name": "Single page only",
+    "value": "{\n  \"url\": \"https://www.scrapingcourse.com/ecommerce/\",\n  \"maxPages\": 1\n}",
+    "lastUsed": false,
+    "id": "b8c9d0e1-f2a3-4567-1234-56789abcdef0"
+  }
+]
+

--- a/typescript-examples/jsdom-example/api/details.ts
+++ b/typescript-examples/jsdom-example/api/details.ts
@@ -1,0 +1,119 @@
+import { BrowserContext, Page } from "playwright";
+import { goToUrl } from "@intuned/browser";
+import { JSDOM } from "jsdom";
+import { z } from "zod";
+
+import { detailsSchema, ProductDetails } from "../utils/typesAndSchemas.js";
+
+type Params = z.infer<typeof detailsSchema>;
+
+function extractProductDetails(html: string, params: Params): ProductDetails {
+  /**
+   * Extracts detailed product information from the page HTML using JSDOM.
+   * Replace selectors with appropriate ones for your target site.
+   */
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  // Extract description - replace selector as needed
+  const descriptionElement = document.querySelector("#tab-description p");
+  const description = descriptionElement?.textContent?.trim() || "";
+
+  // Extract SKU - replace selector as needed
+  const skuElement = document.querySelector(".sku");
+  const sku = skuElement?.textContent?.trim() || "";
+
+  // Extract category - replace selector as needed
+  const categoryElement = document.querySelector(".posted_in a");
+  const category = categoryElement?.textContent?.trim() || "";
+
+  // Extract sizes from select options - replace selector as needed
+  const sizeOptions = document.querySelectorAll("#size option");
+  const sizes: string[] = [];
+  sizeOptions.forEach((opt) => {
+    const value = opt.getAttribute("value");
+    if (value && value !== "") {
+      sizes.push(opt.textContent?.trim() || "");
+    }
+  });
+
+  // Extract colors from select options - replace selector as needed
+  const colorOptions = document.querySelectorAll("#color option");
+  const colors: string[] = [];
+  colorOptions.forEach((opt) => {
+    const value = opt.getAttribute("value");
+    if (value && value !== "") {
+      colors.push(opt.textContent?.trim() || "");
+    }
+  });
+
+  // Extract product images - replace selector as needed
+  const imageElements = document.querySelectorAll(
+    ".woocommerce-product-gallery__image img"
+  );
+  const images: string[] = [];
+  imageElements.forEach((img) => {
+    const src = img.getAttribute("src");
+    if (src) {
+      images.push(src);
+    }
+  });
+
+  return {
+    title: params.title,
+    price: params.price,
+    sourceUrl: params.detailsUrl,
+    description,
+    sku,
+    category,
+    sizes,
+    colors,
+    images,
+  };
+}
+
+export default async function handler(
+  params: Params,
+  page: Page,
+  context: BrowserContext
+): Promise<ProductDetails> {
+  /**
+   * Scrapes product details from a product page using JSDOM.
+   * This API is called via extendPayload from the list API.
+   *
+   * Expected params (from list.ts extendPayload):
+   * {
+   *   "title": "Product Name",
+   *   "price": "$19.99",
+   *   "detailsUrl": "https://www.scrapingcourse.com/ecommerce/product/example"
+   * }
+   *
+   * This function:
+   * 1. Navigates to the product details page
+   * 2. Extracts additional product information using JSDOM
+   * 3. Returns complete product details
+   */
+
+  // Validate required params
+  if (!params.detailsUrl) {
+    throw new Error("detailsUrl is required in params");
+  }
+
+  const detailsUrl = params.detailsUrl;
+  console.log(`Scraping product details from: ${detailsUrl}`);
+
+  // Navigate to the product page
+  await goToUrl({ page, url: detailsUrl });
+
+  // Wait for the product content to load - replace selector as needed
+  await page.waitForSelector(".product");
+
+  // Get the page HTML
+  const html = await page.content();
+
+  // Extract product details using JSDOM
+  const productDetails = extractProductDetails(html, params);
+
+  console.log(`Successfully scraped details for: ${productDetails.title}`);
+  return productDetails;
+}

--- a/typescript-examples/jsdom-example/api/list.ts
+++ b/typescript-examples/jsdom-example/api/list.ts
@@ -1,0 +1,140 @@
+import { BrowserContext, Page } from "playwright";
+import { goToUrl } from "@intuned/browser";
+import { extendPayload } from "@intuned/runtime";
+import { JSDOM } from "jsdom";
+import { z } from "zod";
+import { listSchema, Product } from "../utils/typesAndSchemas.js";
+
+type Params = z.infer<typeof listSchema>;
+
+function extractProducts(html: string): Product[] {
+  /**
+   * Extracts product info from the page HTML using JSDOM.
+   * Replace selectors with appropriate ones for your target site.
+   */
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+  const products: Product[] = [];
+
+  // Find all product items - replace selector as needed
+  const productElements = document.querySelectorAll("li.product");
+
+  productElements.forEach((product) => {
+    // Extract title - replace selector as needed
+    const titleElement = product.querySelector(
+      "h2.woocommerce-loop-product__title"
+    );
+    const title = titleElement?.textContent?.trim() || "";
+
+    // Extract price - replace selector as needed
+    const priceElement = product.querySelector("span.woocommerce-Price-amount");
+    const price = priceElement?.textContent?.trim() || "";
+
+    // Extract details URL - replace selector as needed
+    const linkElement = product.querySelector("a.woocommerce-LoopProduct-link");
+    const detailsUrl = linkElement?.getAttribute("href") || "";
+
+    if (title && detailsUrl) {
+      products.push({
+        title,
+        price,
+        detailsUrl,
+      });
+    }
+  });
+
+  return products;
+}
+
+function getNextPageUrl(html: string): string | null {
+  /**
+   * Extracts the next page URL from pagination.
+   * Returns null if there is no next page.
+   */
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  // Find the next page link - replace selector as needed
+  const nextLink = document.querySelector("a.next.page-numbers");
+
+  if (nextLink) {
+    return nextLink.getAttribute("href");
+  }
+
+  return null;
+}
+
+export default async function handler(
+  params: Params,
+  page: Page,
+  context: BrowserContext
+) {
+  /**
+   * Scrapes product listings from an e-commerce site using JSDOM.
+   * Handles pagination by following "Next" page links.
+   *
+   * Example params:
+   * {
+   *   "url": "https://www.scrapingcourse.com/ecommerce/",
+   *   "maxPages": 5
+   * }
+   *
+   * This function:
+   * 1. Navigates to the listing page
+   * 2. Extracts product data using JSDOM
+   * 3. Follows pagination links to scrape multiple pages
+   * 4. Returns all products found
+   */
+
+  // Set default values
+  const url = params.url;
+  if (!url) {
+    throw new Error("url is required in params");
+  }
+  const maxPages = params.maxPages ?? 10;
+
+  console.log(`Starting scrape from: ${url}`);
+  console.log(`Max pages: ${maxPages}`);
+
+  const allProducts: Product[] = [];
+  let currentUrl: string | null = url;
+  let currentPage = 1;
+
+  while (currentUrl && currentPage <= maxPages) {
+    console.log(`Scraping page ${currentPage}: ${currentUrl}`);
+
+    // Navigate to the page
+    await goToUrl({ page, url: currentUrl });
+
+    // Wait for products to load - replace selector as needed
+    await page.waitForSelector("li.product");
+
+    // Get the page HTML
+    const html = await page.content();
+
+    // Extract products using JSDOM
+    const products = extractProducts(html);
+    allProducts.push(...products);
+
+    console.log(`Found ${products.length} products on page ${currentPage}`);
+
+    // Get next page URL
+    currentUrl = getNextPageUrl(html);
+    currentPage += 1;
+  }
+
+  console.log(`Total products scraped: ${allProducts.length}`);
+
+  for (const product of allProducts) {
+    extendPayload({
+      api: "details",
+      parameters: product,
+    });
+  }
+
+  return {
+    products: allProducts,
+    count: allProducts.length,
+    pagesScraped: currentPage - 1,
+  };
+}

--- a/typescript-examples/jsdom-example/package.json
+++ b/typescript-examples/jsdom-example/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "book-consultations",
+  "name": "jsdom-example",
   "version": "1.0.0",
-  "description": "Booking automation to book a consultation with a consultant and list the consultations",
+  "description": "JSDOM example to scrape products from a website",
   "main": "index.js",
   "tags": [],
   "scripts": {

--- a/typescript-examples/jsdom-example/package.json
+++ b/typescript-examples/jsdom-example/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "book-consultations",
+  "version": "1.0.0",
+  "description": "Booking automation to book a consultation with a consultant and list the consultations",
+  "main": "index.js",
+  "tags": [],
+  "scripts": {
+    "intuned": "intuned"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@intuned/browser": "0.1.5",
+    "@intuned/runtime": "1.3.11",
+    "@types/node": "^20.10.3",
+    "jsdom": "^27.3.0",
+    "playwright": "~1.56.0",
+    "zod": "^3.22.4"
+  }
+}

--- a/typescript-examples/jsdom-example/tsconfig.json
+++ b/typescript-examples/jsdom-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "target": "ES2021",
+    "outDir": "./dist",
+    "sourceMap": false,
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/typescript-examples/jsdom-example/utils/typesAndSchemas.ts
+++ b/typescript-examples/jsdom-example/utils/typesAndSchemas.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const listSchema = z.object({
+  url: z.string().url(), // The URL to scrape (e.g.: https://www.scrapingcourse.com/ecommerce/)
+  maxPages: z.number().optional(), // Maximum number of pages to scrape (default: 10)
+});
+
+export const detailsSchema = z.object({
+  title: z.string(),
+  price: z.string(),
+  detailsUrl: z.string().url(),
+});
+
+export interface Product {
+  title: string;
+  price: string;
+  detailsUrl: string;
+}
+
+export interface ProductDetails {
+  title: string;
+  price: string;
+  sourceUrl: string;
+  description: string;
+  sku: string;
+  category: string;
+  sizes: string[];
+  colors: string[];
+  images: string[];
+}


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [x] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [x] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [x] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [x] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [x] Main README and language-specific README updated if adding/modifying examples

