### PR TITLE
add stagehand & browser-use templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [rpa-auth-example](./typescript-examples/rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
 | [e-commerece-shopify](./typescript-examples/e-commerece-shopify/) | Shopify store product scraper |
 | [jsdom-example](./typescript-examples/jsdom-example/) | Web scraping with JSDOM for HTML parsing |
+| [stagehand-template](./typescript-examples/stagehand-template/) | AI browser automation with Stagehand |
 
 ## Python Examples
 
@@ -19,3 +20,5 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [rpa-auth-example](./python-examples/rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
 | [e-commerece-shopify](./python-examples/e-commerece-shopify/) | Shopify store product scraper |
 | [bs4-example](./python-examples/bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |
+| [stagehand-template](./python-examples/stagehand-template/) | AI browser automation with Stagehand |
+| [browser-use](./python-examples/browser-use/) | AI browser automation with Browser-Use |

--- a/python-examples/README.md
+++ b/python-examples/README.md
@@ -11,3 +11,5 @@ Intuned sample projects in Python.
 | [bs4-example](./bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving & stealth mode usage examples |
 | [captcha-solving-auth-example](./captcha-solving-auth-example/) | E-commerce scraper with captcha solving & stealth mode |
+| [stagehand-template](./stagehand-template/) | AI browser automation with Stagehand |
+| [browser-use](./browser-use/) | AI browser automation with Browser-Use |

--- a/python-examples/browser-use/.env.example
+++ b/python-examples/browser-use/.env.example
@@ -1,0 +1,1 @@
+INTUNED_API_KEY=your_api_key_here

--- a/python-examples/browser-use/.gitignore
+++ b/python-examples/browser-use/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/python-examples/browser-use/Intuned.jsonc
+++ b/python-examples/browser-use/Intuned.jsonc
@@ -1,0 +1,15 @@
+// For more information, see our Intuned settings reference
+// https://docs.intunedhq.com/docs/05-references/intuned-json
+{
+  "projectName": "browser-use",
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  }
+}

--- a/python-examples/browser-use/README.md
+++ b/python-examples/browser-use/README.md
@@ -1,0 +1,132 @@
+# browser-use-book-room Intuned project
+
+Using Browser-Use with Intuned
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+uv sync
+```
+
+After installing dependencies, `intuned` command should be available in your environment.
+
+### Run an API
+```bash
+uv run intuned run api <api-name> <parameters>
+```
+
+### Deploy project
+```bash
+uv run intuned deploy
+```
+
+
+
+
+### `intuned-browser`: Intuned Browser SDK
+
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+
+
+### `intuned-runtime`: Intuned Runtime SDK
+
+All intuned projects use the Intuned runtime SDK. It also exposes some helpers for nested scheduling and auth sessions. This project uses some of these helpers. For more information, check out the documentation coming soon.
+
+This project uses the `setup_context` hook from the Intuned runtime SDK. This hook is used to set up the browser context and page for the project. For more information, check out the documentation coming soon.
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── apis/                     # Your API endpoints 
+│   └── ...   
+├── auth-sessions/            # Auth session related APIs
+│   ├── check.py           # API to check if the auth session is still valid
+│   └── create.py          # API to create/recreate the auth session programmatically
+├── auth-sessions-instances/  # Auth session instances created and used by the CLI
+│   └── ...
+└── intuned.json              # Intuned project configuration file
+```
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // Your Intuned workspace ID. 
+  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
+  "workspaceId": "your_workspace_id",
+
+  // The name of your Intuned project. 
+  // Optional - If not provided here, it must be supplied via the command line when deploying.
+  "projectName": "your_project_name",
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
+    // A number of machines equal to this will be allocated to handle API requests.
+    // Not applicable if api access is disabled.
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project. This is applicable for both API requests and jobs.
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  }
+
+  // Auth session settings
+  "authSessions": {
+    // Whether auth sessions are enabled for this project.
+    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
+    "enabled": true,
+
+    // Whether to save Playwright traces for auth session runs.
+    "saveTraces": false,
+
+    // The type of auth session to use.
+    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
+    // "MANUAL" type uses a recorder to manually create the auth session.
+    "type": "API",
+    
+
+    // Recorder start URL for the recorder to navigate to when creating the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "startUrl": "https://example.com/login",
+
+    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "finishUrl": "https://example.com/dashboard",
+
+    // Recorder browser mode
+    // "fullscreen": Launches the browser in fullscreen mode.
+    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
+    // Only applicable for "MANUAL" type.
+    "browserMode": "fullscreen"
+  }
+  
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
+    // This is required for projects that use auth sessions.
+    "enabled": true
+  },
+
+  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
+  "headful": false,
+
+  // The region where your Intuned project is hosted.
+  // For a list of available regions, contact support or refer to the documentation.
+  // Optional - Default: "us"
+  "region": "us"
+}
+```
+  

--- a/python-examples/browser-use/____testParameters/book_room.json
+++ b/python-examples/browser-use/____testParameters/book_room.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Params #1",
+    "value": "{\n  \"check_in_date\": \"12 sep. 2025\",\n  \"check_out_date\": \"14 sep. 2025\",\n  \"budget\": 200,\n  \"first_name\": \"Test\",\n  \"last_name\": \"User\",\n  \"phone_number\": \"012345678900\",\n  \"email\": \"test@user.me\",\n  \"extra_details\": \"Wifi is preferable but not required\"\n}",
+    "lastUsed": true,
+    "id": "5db5d935-de48-4169-9de5-563930eec8d4"
+  }
+]

--- a/python-examples/browser-use/api/book_room.py
+++ b/python-examples/browser-use/api/book_room.py
@@ -1,0 +1,49 @@
+from playwright.async_api import Page
+from typing import TypedDict
+from browser_use import Agent, ChatOpenAI, Browser, Tools
+from intuned_runtime import attempt_store
+
+
+class Params(TypedDict):
+    check_in_date: str
+    check_out_date: str
+    budget: float
+    first_name: str
+    last_name: str
+    phone_number: str
+    email: str
+    extra_details: str
+
+
+async def automation(page: Page, params: Params | None = None, **_kwargs):
+    if params is None:
+        raise Exception("params cannot be null")
+    browser: Browser = attempt_store.get("browser")
+
+    check_in_date = params["check_in_date"]
+    check_out_date = params["check_out_date"]
+    budget = params["budget"]
+    first_name = params["first_name"]
+    last_name = params["last_name"]
+    phone_number = params["phone_number"]
+    email = params["email"]
+    extra_details = params["extra_details"]
+
+    tools = Tools()
+
+    agent = Agent(
+        browser=browser,
+        task=f"""1. Go to https://automationintesting.online.
+2. Fill in the check-in date '{check_in_date}' and check-out date '{check_out_date}' in the format DD/MM/YYYY (all numbers). Hit search.
+3. Find a room that is within the budget of '{budget} pounds'. {f"Keep in mind the following: '{extra_details}'" if extra_details else ""}
+4. Book the room with first name '{first_name}' last name '{last_name}' phone number '{phone_number}' email '{email}'""",
+        llm=ChatOpenAI(model="gpt-5-nano", temperature=0),
+        flash_mode=True,
+        tools=tools,
+    )
+
+    # Agent will run the task on current browser page
+    # Since Browser-use uses CDP directly, the actions done by the agent won't be visible in the Playwright trace
+    await agent.run()
+
+    return None

--- a/python-examples/browser-use/hooks/setup_context.py
+++ b/python-examples/browser-use/hooks/setup_context.py
@@ -1,0 +1,8 @@
+from intuned_runtime import attempt_store
+
+
+async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
+    from browser_use import Browser
+    browser = Browser(cdp_url=cdp_url)
+    attempt_store.set("browser", browser)
+    return

--- a/python-examples/browser-use/pyproject.toml
+++ b/python-examples/browser-use/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "browser-use-book-room"
+version = "0.0.1"
+description = "Using Browser-Use with Intuned"
+authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
+requires-python = ">=3.12,<3.13"
+readme = "README.md"
+keywords = [
+    "Python",
+    "AI",
+    "Browser Use",
+    "intuned-browser-sdk",
+    "intuned-runtime-sdk",
+    "intuned-runtime-sdk-setup-context-hook",
+]
+dependencies = [
+    "playwright==1.56",
+    "intuned-runtime==1.3.12",
+    "browser-use==0.7.6",
+    "intuned-browser==0.1.10",
+]
+
+[tool.uv]
+package = false

--- a/python-examples/stagehand-template/.env.example
+++ b/python-examples/stagehand-template/.env.example
@@ -1,0 +1,1 @@
+INTUNED_API_KEY=your_api_key_here

--- a/python-examples/stagehand-template/.gitignore
+++ b/python-examples/stagehand-template/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/python-examples/stagehand-template/Intuned.jsonc
+++ b/python-examples/stagehand-template/Intuned.jsonc
@@ -1,0 +1,15 @@
+// For more information, see our Intuned settings reference
+// https://docs.intunedhq.com/docs/05-references/intuned-json
+{
+  "projectName": "stagehand-template",
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  }
+}

--- a/python-examples/stagehand-template/README.md
+++ b/python-examples/stagehand-template/README.md
@@ -1,0 +1,132 @@
+# stagehand-stock-details Intuned project
+
+Using Stagehand with Intuned
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+uv sync
+```
+
+After installing dependencies, `intuned` command should be available in your environment.
+
+### Run an API
+```bash
+uv run intuned run api <api-name> <parameters>
+```
+
+### Deploy project
+```bash
+uv run intuned deploy
+```
+
+
+
+
+### `intuned-browser`: Intuned Browser SDK
+
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+
+
+### `intuned-runtime`: Intuned Runtime SDK
+
+All intuned projects use the Intuned runtime SDK. It also exposes some helpers for nested scheduling and auth sessions. This project uses some of these helpers. For more information, check out the documentation coming soon.
+
+This project uses the `setup_context` hook from the Intuned runtime SDK. This hook is used to set up the browser context and page for the project. For more information, check out the documentation coming soon.
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── apis/                     # Your API endpoints 
+│   └── ...   
+├── auth-sessions/            # Auth session related APIs
+│   ├── check.py           # API to check if the auth session is still valid
+│   └── create.py          # API to create/recreate the auth session programmatically
+├── auth-sessions-instances/  # Auth session instances created and used by the CLI
+│   └── ...
+└── intuned.json              # Intuned project configuration file
+```
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // Your Intuned workspace ID. 
+  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
+  "workspaceId": "your_workspace_id",
+
+  // The name of your Intuned project. 
+  // Optional - If not provided here, it must be supplied via the command line when deploying.
+  "projectName": "your_project_name",
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
+    // A number of machines equal to this will be allocated to handle API requests.
+    // Not applicable if api access is disabled.
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project. This is applicable for both API requests and jobs.
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  }
+
+  // Auth session settings
+  "authSessions": {
+    // Whether auth sessions are enabled for this project.
+    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
+    "enabled": true,
+
+    // Whether to save Playwright traces for auth session runs.
+    "saveTraces": false,
+
+    // The type of auth session to use.
+    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
+    // "MANUAL" type uses a recorder to manually create the auth session.
+    "type": "API",
+    
+
+    // Recorder start URL for the recorder to navigate to when creating the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "startUrl": "https://example.com/login",
+
+    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "finishUrl": "https://example.com/dashboard",
+
+    // Recorder browser mode
+    // "fullscreen": Launches the browser in fullscreen mode.
+    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
+    // Only applicable for "MANUAL" type.
+    "browserMode": "fullscreen"
+  }
+  
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
+    // This is required for projects that use auth sessions.
+    "enabled": true
+  },
+
+  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
+  "headful": false,
+
+  // The region where your Intuned project is hosted.
+  // For a list of available regions, contact support or refer to the documentation.
+  // Optional - Default: "us"
+  "region": "us"
+}
+```
+  

--- a/python-examples/stagehand-template/____testParameters/get_stock_details.json
+++ b/python-examples/stagehand-template/____testParameters/get_stock_details.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Most advanced",
+    "value": "{\n  \"criteria\": \"most advanced stock today\"\n}",
+    "lastUsed": true,
+    "id": "5db5d935-de48-4169-9de5-563930eec8d4"
+  }
+]

--- a/python-examples/stagehand-template/api/get_stock_details.py
+++ b/python-examples/stagehand-template/api/get_stock_details.py
@@ -1,0 +1,41 @@
+from typing import TypedDict, cast
+from intuned_runtime import attempt_store
+from pydantic import BaseModel
+from stagehand import Stagehand, StagehandPage
+import os
+
+
+class Params(TypedDict):
+    criteria: str
+
+
+async def automation(page: StagehandPage, params: Params, *args: ..., **kwargs: ...):
+    criteria = params["criteria"]
+    stagehand = cast(Stagehand, attempt_store.get("stagehand"))
+
+    await page.goto("https://www.nasdaq.com/market-activity/stocks")
+
+    agent = stagehand.agent(
+        provider="openai",
+        model="computer-use-preview",
+        options={"apiKey": os.getenv("OPENAI_API_KEY")},
+    )
+
+    # Agent runs on current Stagehand page
+    await agent.execute(
+        f"Find and open the page on one stock based on the following criteria: {criteria}.",
+    )
+
+    class StockDetails(BaseModel):
+        name: str
+        symbol: str
+        industry: str
+        shareVolume: int | None = None
+        averageVolume: int | None = None
+        marketCap: int
+
+    # Extract stock details from the page using Stagehand
+    return await page.extract(
+        "Extract the stock details. If the current page is not a stock page, return null",
+        schema=StockDetails,
+    )

--- a/python-examples/stagehand-template/hooks/setup_context.py
+++ b/python-examples/stagehand-template/hooks/setup_context.py
@@ -1,0 +1,15 @@
+from intuned_runtime import attempt_store
+from stagehand import Stagehand
+
+
+async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
+    stagehand = Stagehand(
+        env="LOCAL", local_browser_launch_options=dict(cdp_url=cdp_url)
+    )
+    await stagehand.init()
+    attempt_store.set("stagehand", stagehand)
+
+    async def cleanup():
+        await stagehand.close()
+
+    return stagehand.context, stagehand.page, cleanup

--- a/python-examples/stagehand-template/pyproject.toml
+++ b/python-examples/stagehand-template/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "stagehand-stock-details"
+version = "0.0.1"
+description = "Using Stagehand with Intuned"
+authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
+requires-python = ">=3.12,<3.13"
+readme = "README.md"
+keywords = [
+    "Python",
+    "AI",
+    "Stagehand",
+    "intuned-browser-sdk",
+    "intuned-runtime-sdk",
+    "intuned-runtime-sdk-setup-context-hook",
+]
+dependencies = [
+    "playwright==1.56",
+    "intuned-runtime==1.3.12",
+    "stagehand==0.5.3",
+    "intuned-browser==0.1.10",
+]
+
+[tool.uv]
+package = false

--- a/typescript-examples/README.md
+++ b/typescript-examples/README.md
@@ -11,3 +11,4 @@ Intuned sample projects in TypeScript.
 | [jsdom-example](./jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving usage examples |
 | [captcha-solving-auth-example](./captcha-solving-auth-example/) | E-commerce scraper with captcha |
+| [stagehand-template](./stagehand-template/) | AI browser automation with Stagehand |

--- a/typescript-examples/stagehand-template/.env.example
+++ b/typescript-examples/stagehand-template/.env.example
@@ -1,0 +1,1 @@
+INTUNED_API_KEY=your_api_key_here

--- a/typescript-examples/stagehand-template/.gitignore
+++ b/typescript-examples/stagehand-template/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/typescript-examples/stagehand-template/Intuned.jsonc
+++ b/typescript-examples/stagehand-template/Intuned.jsonc
@@ -1,0 +1,15 @@
+// For more information, see our Intuned settings reference
+// https://docs.intunedhq.com/docs/05-references/intuned-json
+{
+  "projectName": "stagehand-template",
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  }
+}

--- a/typescript-examples/stagehand-template/README.md
+++ b/typescript-examples/stagehand-template/README.md
@@ -1,0 +1,144 @@
+# stagehand Intuned project
+
+Using Stagehand in Intuned
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# npm
+npm install
+
+# yarn
+yarn
+```
+
+> **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
+
+
+### Run an API
+
+```bash
+# npm
+npm run intuned run api <api-name> <parameters>
+
+# yarn
+yarn intuned run api <api-name> <parameters>
+```
+
+### Deploy project
+```bash
+# npm
+npm run intuned deploy
+
+# yarn
+yarn intuned deploy
+
+```
+
+
+
+
+
+
+### `@intuned/runtime`: Intuned Runtime SDK
+
+All intuned projects use the Intuned runtime SDK. It also exposes some helpers for nested scheduling and auth sessions. This project uses some of these helpers. For more information, check out the documentation coming soon.
+
+This project uses the `setupContext` hook from the Intuned runtime SDK. This hook is used to set up the browser context and page for the project. For more information, check out the documentation coming soon.
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── apis/                     # Your API endpoints 
+│   └── ...   
+├── auth-sessions/            # Auth session related APIs
+│   ├── check.ts           # API to check if the auth session is still valid
+│   └── create.ts          # API to create/recreate the auth session programmatically
+├── auth-sessions-instances/  # Auth session instances created and used by the CLI
+│   └── ...
+└── intuned.json              # Intuned project configuration file
+```
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // Your Intuned workspace ID. 
+  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
+  "workspaceId": "your_workspace_id",
+
+  // The name of your Intuned project. 
+  // Optional - If not provided here, it must be supplied via the command line when deploying.
+  "projectName": "your_project_name",
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
+    // A number of machines equal to this will be allocated to handle API requests.
+    // Not applicable if api access is disabled.
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project. This is applicable for both API requests and jobs.
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  }
+
+  // Auth session settings
+  "authSessions": {
+    // Whether auth sessions are enabled for this project.
+    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
+    "enabled": true,
+
+    // Whether to save Playwright traces for auth session runs.
+    "saveTraces": false,
+
+    // The type of auth session to use.
+    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
+    // "MANUAL" type uses a recorder to manually create the auth session.
+    "type": "API",
+    
+
+    // Recorder start URL for the recorder to navigate to when creating the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "startUrl": "https://example.com/login",
+
+    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
+    // Required if "type" is "MANUAL". Not used if "type" is "API".
+    "finishUrl": "https://example.com/dashboard",
+
+    // Recorder browser mode
+    // "fullscreen": Launches the browser in fullscreen mode.
+    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
+    // Only applicable for "MANUAL" type.
+    "browserMode": "fullscreen"
+  }
+  
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
+    // This is required for projects that use auth sessions.
+    "enabled": true
+  },
+
+  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
+  "headful": false,
+
+  // The region where your Intuned project is hosted.
+  // For a list of available regions, contact support or refer to the documentation.
+  // Optional - Default: "us"
+  "region": "us"
+}
+```
+  

--- a/typescript-examples/stagehand-template/____testParameters/getStockDetails.json
+++ b/typescript-examples/stagehand-template/____testParameters/getStockDetails.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Most advanced",
+    "value": "{\n  \"criteria\": \"most advanced stock today\"\n}",
+    "lastUsed": true,
+    "id": "5db5d935-de48-4169-9de5-563930eec8d4"
+  }
+]

--- a/typescript-examples/stagehand-template/api/getStockDetails.ts
+++ b/typescript-examples/stagehand-template/api/getStockDetails.ts
@@ -1,0 +1,46 @@
+import z from "zod";
+import type { Page, Stagehand } from "@browserbasehq/stagehand";
+import { attemptStore } from "@intuned/runtime";
+
+interface Params {
+  criteria: string;
+}
+type BrowserContext = Stagehand["context"];
+export default async function handler(
+  { criteria }: Params,
+  page: Page,
+  _: BrowserContext
+) {
+  const stagehand: Stagehand = attemptStore.get("stagehand");
+
+  await page.goto("https://www.nasdaq.com/market-activity/stocks");
+
+  const agent = stagehand.agent({});
+
+  // Agent runs on current Stagehand page
+  await agent.execute({
+    instruction: `Find and open the page on one stock based on the following criteria: ${criteria}.`,
+  });
+
+  const stockDetailsSchema = z.object({
+    stock: z
+      .object({
+        name: z.string(),
+        symbol: z.string(),
+        industry: z.string(),
+        shareVolume: z.number().optional(),
+        averageVolume: z.number().optional(),
+        marketCap: z.number(),
+      })
+      .nullable(),
+  });
+
+  // Extract stock details from the page using Stagehand
+  return await stagehand.extract(
+    "Extract the stock details. If the current page is not a stock page, return null",
+    stockDetailsSchema,
+    {
+      page: page,
+    }
+  );
+}

--- a/typescript-examples/stagehand-template/hooks/setupContext.ts
+++ b/typescript-examples/stagehand-template/hooks/setupContext.ts
@@ -1,0 +1,42 @@
+import { Stagehand } from "@browserbasehq/stagehand";
+import { attemptStore } from "@intuned/runtime";
+
+async function getWebSocketUrl(cdpUrl: string) {
+  const versionUrl = cdpUrl.endsWith("/")
+    ? `${cdpUrl}json/version`
+    : `${cdpUrl}/json/version`;
+  const response = await fetch(versionUrl);
+  const data = await response.json();
+  return data.webSocketDebuggerUrl;
+}
+
+export default async function setupContext({
+  cdpUrl,
+}: {
+  cdpUrl: string;
+  apiName: string;
+  apiParameters: any;
+}) {
+  const webSocketUrl = await getWebSocketUrl(cdpUrl);
+  const stagehand = new Stagehand({
+    env: "LOCAL",
+    localBrowserLaunchOptions: {
+      cdpUrl: webSocketUrl,
+    },
+
+    // this is needed since Stagehand uses pino which spawns a worker thread, which is not currently supported in Intuned
+    logger: console.log,
+  });
+
+  await stagehand.init();
+
+  attemptStore.set("stagehand", stagehand);
+
+  return {
+    context: stagehand.context as any,
+    page: stagehand.context.pages()[0] as any,
+    cleanup: async () => {
+      await stagehand.close();
+    },
+  };
+}

--- a/typescript-examples/stagehand-template/package.json
+++ b/typescript-examples/stagehand-template/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "stagehand",
+  "version": "1.0.0",
+  "description": "Using Stagehand in Intuned",
+  "tags": [
+    "Stagehand",
+    "AI",
+    "intuned-runtime-sdk",
+    "intuned-runtime-sdk-setup-context-hook"
+  ],
+  "main": "index.js",
+  "scripts": {
+    "intuned": "intuned"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@browserbasehq/stagehand": "3.0.6",
+    "@intuned/browser": "0.1.7",
+    "@intuned/runtime": "1.3.12",
+    "@types/node": "^20.10.3",
+    "playwright": "~1.56.0",
+    "zod": "3.25.67"
+  }
+}

--- a/typescript-examples/stagehand-template/tsconfig.json
+++ b/typescript-examples/stagehand-template/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "target": "ES2021",
+    "outDir": "./dist",
+    "sourceMap": false,
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [x] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [x] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [x] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [x] Main README and language-specific README updated if adding/modifying examples

