### PR TITLE
Move e-commerce projects from webapp and remove response handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ htmlcov/
 .intuned/
 
 notes.md
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [auth-with-secret-otp](./typescript-examples/auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
 | [auth-with-email-otp](./typescript-examples/auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
 | [e-commerce-scrapingcourse](./typescript-examples/e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
+| [e-commerce-auth-scrapingcourse](./typescript-examples/e-commerce-auth-scrapingcourse/) | Authenticated e-commerce scraper with Auth Sessions |
 | [e-commerece-shopify](./typescript-examples/e-commerece-shopify/) | Shopify store product scraper |
 | [jsdom-example](./typescript-examples/jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 
@@ -23,5 +24,6 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [auth-with-secret-otp](./python-examples/auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
 | [auth-with-email-otp](./python-examples/auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
 | [e-commerce-scrapingcourse](./python-examples/e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
+| [e-commerce-auth-scrapingcourse](./python-examples/e-commerce-auth-scrapingcourse/) | Authenticated e-commerce scraper with Auth Sessions |
 | [e-commerece-shopify](./python-examples/e-commerece-shopify/) | Shopify store product scraper |
 | [bs4-example](./python-examples/bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [quick-recipes](./typescript-examples/quick-recipes/) | Quick browser automation recipes |
 | [rpa-example](./typescript-examples/rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./typescript-examples/rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
+| [auth-with-secret-otp](./typescript-examples/auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
+| [auth-with-email-otp](./typescript-examples/auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
+| [e-commerce-scrapingcourse](./typescript-examples/e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
 | [e-commerece-shopify](./typescript-examples/e-commerece-shopify/) | Shopify store product scraper |
 | [jsdom-example](./typescript-examples/jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 
@@ -17,5 +20,8 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [quick-recipes](./python-examples/quick-recipes/) | Quick browser automation recipes |
 | [rpa-example](./python-examples/rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./python-examples/rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
+| [auth-with-secret-otp](./python-examples/auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
+| [auth-with-email-otp](./python-examples/auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
+| [e-commerce-scrapingcourse](./python-examples/e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
 | [e-commerece-shopify](./python-examples/e-commerece-shopify/) | Shopify store product scraper |
 | [bs4-example](./python-examples/bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |

--- a/python-examples/README.md
+++ b/python-examples/README.md
@@ -10,6 +10,7 @@ Intuned sample projects in Python.
 | [auth-with-secret-otp](./auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
 | [auth-with-email-otp](./auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
 | [e-commerce-scrapingcourse](./e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
+| [e-commerce-auth-scrapingcourse](./e-commerce-auth-scrapingcourse/) | Authenticated e-commerce scraper with Auth Sessions |
 | [e-commerece-shopify](./e-commerece-shopify/) | Shopify store product scraper |
 | [bs4-example](./bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving & stealth mode usage examples |

--- a/python-examples/README.md
+++ b/python-examples/README.md
@@ -7,6 +7,9 @@ Intuned sample projects in Python.
 | [quick-recipes](./quick-recipes/) | Quick browser automation recipes |
 | [rpa-example](./rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
+| [auth-with-secret-otp](./auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
+| [auth-with-email-otp](./auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
+| [e-commerce-scrapingcourse](./e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
 | [e-commerece-shopify](./e-commerece-shopify/) | Shopify store product scraper |
 | [bs4-example](./bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving & stealth mode usage examples |

--- a/python-examples/auth-with-secret-otp/api/list-contracts.py
+++ b/python-examples/auth-with-secret-otp/api/list-contracts.py
@@ -1,24 +1,8 @@
-from typing import Optional, List, Union
+from typing import Optional, List
 from playwright.async_api import Page
-from pydantic import BaseModel
 from intuned_browser import go_to_url
 
-
 from utils.types_and_schemas import Contract
-
-
-class SuccessResponse(BaseModel):
-    success: bool = True
-    contracts: List[Contract]
-
-
-class ErrorResponse(BaseModel):
-    success: bool = False
-    message: str
-    error: str
-
-
-HandlerResponse = Union[SuccessResponse, ErrorResponse]
 
 
 async def extract_contracts_from_table(page: Page) -> List[Contract]:
@@ -89,28 +73,14 @@ async def extract_contracts_from_table(page: Page) -> List[Contract]:
 
 async def handler(
     page: Page, params: Optional[dict] = None, **_kwargs
-) -> HandlerResponse:
-    try:
-        # Navigate to the contracts list authentication page
-        await go_to_url(
-            page=page,
-            url="https://sandbox.intuned.dev/list-auth",
-        )
+) -> List[Contract]:
+    # Navigate to the contracts list authentication page
+    await go_to_url(
+        page=page,
+        url="https://sandbox.intuned.dev/list-auth",
+    )
 
-        contracts = await extract_contracts_from_table(page)
+    contracts = await extract_contracts_from_table(page)
 
-        # Return the scraped data
-        return SuccessResponse(success=True, contracts=contracts)
-
-    except Exception as error:
-        # Handle any errors that occur during the scraping process
-        error_message = str(error)
-
-        print(f"Failed to extract contracts: {error_message}")
-
-        # Return error response instead of raising
-        return ErrorResponse(
-            success=False,
-            message="Failed to extract contracts from the page",
-            error=error_message,
-        )
+    # Return the scraped data
+    return contracts

--- a/python-examples/e-commerce-auth-scrapingcourse/Intuned.json
+++ b/python-examples/e-commerce-auth-scrapingcourse/Intuned.json
@@ -1,0 +1,33 @@
+{
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": true,
+    "type": "API"
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        "maxConcurrentRequests": 2,
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    },
+    "testAuthSessionInput": {
+      "username": "admin@example.com",
+      "password": "password"
+    }
+  }
+}

--- a/python-examples/e-commerce-auth-scrapingcourse/README.md
+++ b/python-examples/e-commerce-auth-scrapingcourse/README.md
@@ -1,0 +1,214 @@
+# E-Commerce Auth Product Scraper
+
+Authenticated e-commerce scraping automation that extracts product information from a protected dashboard using Auth Sessions.
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# Using uv (recommended)
+uv sync
+
+# Using pip
+pip install -e .
+```
+
+
+### Run an API
+
+```bash
+# Using uv
+uv run intuned run api <api-name> <parameters>
+
+# Using pip
+intuned run api <api-name> <parameters>
+```
+
+#### Example: List Products
+
+```bash
+# List products from authenticated dashboard
+uv run intuned run api list
+```
+
+#### Example: Get Product Details
+
+```bash
+# Get details for a specific product
+uv run intuned run api details '{"name": "Product Name", "detailsUrl": "https://www.scrapingcourse.com/ecommerce/product/example"}'
+```
+
+### Deploy project
+```bash
+# Using uv
+uv run intuned deploy
+
+# Using pip
+intuned deploy
+```
+
+
+## Auth Sessions
+
+This project uses Intuned Auth Sessions to maintain authenticated access to the dashboard. To learn more, check out the [Authenticated Browser Automations: Conceptual Guide](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/authenticated-browser-automations-conceptual-guide).
+
+### Create a new auth session
+```bash
+# Using uv
+uv run intuned run authsession create <parameters>
+
+# Using pip
+intuned run authsession create <parameters>
+
+# Example
+uv run intuned run authsession create '{"username": "admin@example.com", "password": "password"}'
+```
+
+### Update an existing auth session
+```bash
+# Using uv
+uv run intuned run authsession update <auth-session-id>
+
+# Using pip
+intuned run authsession update <auth-session-id>
+```
+
+### Validate an auth session
+```bash
+# Using uv
+uv run intuned run authsession validate <auth-session-id>
+
+# Using pip
+intuned run authsession validate <auth-session-id>
+```
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── api/                      # Your API endpoints
+│   ├── list.py              # API to scrape product list from dashboard
+│   └── details.py           # API to scrape detailed product information
+├── auth-sessions/            # Auth session related APIs
+│   ├── check.py             # API to check if the auth session is still valid
+│   └── create.py            # API to create/recreate the auth session programmatically
+├── utils/                    # Utility files
+│   └── types_and_schemas.py # Python types and Pydantic models
+└── Intuned.json              # Intuned project configuration file
+```
+
+
+## APIs
+
+### `list` - Product List Scraper
+
+Scrapes products from the authenticated dashboard.
+
+**Parameters:**
+None
+
+**Returns:**
+List of products with:
+- `name`: Product name
+- `detailsUrl`: URL to product details page
+
+**Features:**
+- Requires authenticated session
+- Automatically navigates to dashboard
+- Triggers `details` API for each product using `extend_payload`
+
+### `details` - Product Details Scraper
+
+Scrapes detailed information for a specific product.
+
+**Parameters:**
+- `name`: Product name
+- `detailsUrl`: URL to the product details page
+
+**Returns:**
+Product details object with:
+- `name`: Product name
+- `price`: Product price
+- `sku`: Stock Keeping Unit
+- `category`: Product category
+- `shortDescription`: Brief product description
+- `fullDescription`: Complete product description
+- `imageAttachments`: List of product images (uploaded to S3)
+- `availableSizes`: List of available sizes
+- `availableColors`: List of available colors
+- `variants`: List of product variants with stock information
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API
+    "enabled": true
+  },
+
+  // Auth session settings
+  "authSessions": {
+    // Auth sessions are required to access the protected dashboard
+    "enabled": true,
+    // "API" type requires implementing auth-sessions/create.py
+    "type": "API"
+  },
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  },
+
+  // Default job configuration
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        // Number of concurrent API calls within the job
+        "maxConcurrentRequests": 2,
+        // Retry configuration
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    },
+    // Test credentials for auth session creation
+    "testAuthSessionInput": {
+      "username": "admin@example.com",
+      "password": "password"
+    }
+  }
+}
+```
+
+## Using `intuned_browser` SDK
+
+This project uses the Intuned browser SDK for enhanced reliability:
+
+- **`go_to_url`**: Navigate to URLs with automatic retries and intelligent timeout detection
+- **`save_file_to_s3`**: Automatically upload images and files to S3 storage
+- **`extend_payload`**: Trigger additional API calls dynamically (used to trigger `details` API for each product)
+
+For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).

--- a/python-examples/e-commerce-auth-scrapingcourse/____testParameters/create.json
+++ b/python-examples/e-commerce-auth-scrapingcourse/____testParameters/create.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Demo User Login",
+    "value": "{\n  \"username\": \"admin@example.com\",\n  \"password\": \"password\"\n}",
+    "lastUsed": true,
+    "id": "f1a2b3c4-d5e6-4789-a0b1-c2d3e4f5g6h7"
+  }
+]

--- a/python-examples/e-commerce-auth-scrapingcourse/api/details.py
+++ b/python-examples/e-commerce-auth-scrapingcourse/api/details.py
@@ -108,8 +108,8 @@ async def extract_product_details(page: Page, params: DetailsSchema) -> ProductD
     price_element = page.locator(".summary .price .woocommerce-Price-amount").first
     price = await price_element.text_content()
 
-    # Extract id
-    id_element = page.locator(".sku_wrapper .id")
+    # Extract id (Stock Keeping Unit)
+    id_element = page.locator(".sku_wrapper .sku")
     id = await id_element.text_content() or ""
 
     # Extract category

--- a/python-examples/e-commerce-auth-scrapingcourse/api/list.py
+++ b/python-examples/e-commerce-auth-scrapingcourse/api/list.py
@@ -1,0 +1,77 @@
+from playwright.async_api import Page
+from typing import TypedDict, List, Optional
+from runtime_helpers import extend_payload
+from intuned_browser import go_to_url
+
+
+class Product(TypedDict):
+    name: str
+    detailsUrl: str
+
+
+async def extract_products_from_page(page: Page) -> List[Product]:
+    # Wait for the product grid to be visible
+    # This ensures the page has loaded before we try to extract data
+    product_grid = page.locator("#product-grid")
+    await product_grid.wait_for(state="visible")
+
+    # Find all product items within the grid
+    # Each product is contained in a div with class "product-item"
+    product_items = await product_grid.locator(".product-item").all()
+
+    # Array to store all extracted product data
+    products: List[Product] = []
+
+    for product_item in product_items:
+        try:
+            # Extract the product name
+            name_element = product_item.locator(".product-name")
+            name = await name_element.text_content()
+
+            # Extract the product detail page URL
+            link_element = product_item.locator("a")
+            product_url = await link_element.get_attribute("href")
+
+            # Only add the product if all required fields were found
+            if name and product_url:
+                product: Product = {
+                    "name": name.strip(),
+                    "detailsUrl": product_url.strip(),
+                }
+
+                products.append(product)
+                # extend the payload to trigger the details API
+                extend_payload(
+                    {
+                        "api": "details",
+                        "parameters": product,
+                    }
+                )
+        except Exception as error:
+            # If extraction fails for a single product, log it but continue with others
+            print(f"Failed to extract product data: {error}")
+            continue
+
+    return products
+
+
+async def handler(
+    page: Page,
+    params: Optional[dict] = None,
+    **_kwargs,
+) -> List[Product]:
+    # Validate input parameters using schema
+    if params is None:
+        params = {}
+
+    # Navigate to the dashboard page
+    await go_to_url(
+        page=page,
+        url="https://www.scrapingcourse.com/dashboard",
+    )
+
+    # Extract all product details from the page
+    products = await extract_products_from_page(page)
+
+    # Return all extracted products
+    return products

--- a/python-examples/e-commerce-auth-scrapingcourse/auth-sessions/check.py
+++ b/python-examples/e-commerce-auth-scrapingcourse/auth-sessions/check.py
@@ -1,0 +1,20 @@
+from playwright.async_api import Page
+from intuned_browser import go_to_url
+
+
+async def check(page: Page, **_kwargs) -> bool:
+    # Step 1: Navigate to a protected page (dashboard)
+    await go_to_url(
+        page=page,
+        url="https://www.scrapingcourse.com/dashboard",
+    )
+
+    # Step 2: Check if the products grid is visible
+    # The products grid should only be visible on the dashboard if we're logged in
+    # If we were redirected to login, this element won't exist
+    products_grid = page.locator("#product-grid")
+    is_session_valid = await products_grid.is_visible()
+
+    # Return True if the session is still valid (products grid is visible)
+    # Return False if the session expired (we were redirected to login)
+    return is_session_valid

--- a/python-examples/e-commerce-auth-scrapingcourse/auth-sessions/create.py
+++ b/python-examples/e-commerce-auth-scrapingcourse/auth-sessions/create.py
@@ -1,0 +1,42 @@
+from playwright.async_api import Page
+from typing import TypedDict
+from intuned_browser import go_to_url
+
+
+class Params(TypedDict):
+    username: str
+    password: str
+
+
+async def create(page: Page, params: Params | None = None, **_kwargs):
+    if params is None:
+        raise ValueError("Params with username and password are required")
+
+    # Step 1: Navigate to the login page
+    await go_to_url(
+        page=page,
+        url="https://www.scrapingcourse.com/login",
+    )
+
+    # Step 2: Find the email input field and enter the username
+    # The locator finds the element with id="email"
+    email_input = page.locator("#email")
+    await email_input.fill(params["username"])
+
+    # Step 3: Find the password input field and enter the password
+    # The locator finds the element with id="password"
+    password_input = page.locator("#password")
+    await password_input.fill(params["password"])
+
+    # Step 4: Click the submit button to log in
+    # This will submit the login form with the credentials we just entered
+    submit_button = page.locator("#submit-button")
+    await submit_button.click()
+
+    # Step 5: Verify successful login by checking if the products grid is visible
+    # If the products grid is visible, it means we successfully logged in
+    products_grid = page.locator("#product-grid")
+    is_logged_in = await products_grid.is_visible()
+
+    # Return True if login was successful, False otherwise
+    return is_logged_in

--- a/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ecommerce-with-auth"
+version = "0.0.1"
+description = "Credentials based e-commerce automation that extracts product details from a list of products"
+authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
+requires-python = ">=3.12,<3.13"
+readme = "README.md"
+keywords = [
+    "Python",
+    "intuned-browser-sdk",
+]
+dependencies = [
+    "playwright==1.56",
+    "intuned-runtime==1.3.12",
+    "intuned-browser==0.1.9",
+    "pydantic==2.10.6",
+]
+
+[tool.uv]
+package = false

--- a/python-examples/e-commerce-auth-scrapingcourse/utils/types_and_schemas.py
+++ b/python-examples/e-commerce-auth-scrapingcourse/utils/types_and_schemas.py
@@ -1,0 +1,37 @@
+from intuned_browser import Attachment
+from pydantic import BaseModel, HttpUrl, field_validator
+from typing import List
+
+
+class DetailsSchema(BaseModel):
+    name: str
+    detailsUrl: HttpUrl
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not v or len(v.strip()) < 1:
+            raise ValueError("Product name is required")
+        return v
+
+
+class ProductVariant(BaseModel):
+    sku: str
+    size: str
+    color: str
+    availability: str
+    stock: int
+
+
+class ProductDetails(BaseModel):
+    name: str
+    detailsUrl: str
+    price: str
+    id: str
+    category: str
+    shortDescription: str
+    fullDescription: str
+    availableSizes: List[str]
+    availableColors: List[str]
+    variants: List[ProductVariant]
+    imageAttachments: List[Attachment]

--- a/python-examples/e-commerce-scrapingcourse/Intuned.json
+++ b/python-examples/e-commerce-scrapingcourse/Intuned.json
@@ -1,0 +1,28 @@
+{
+  "apiAccess": {
+    "enabled": false
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        "maxConcurrentRequests": 2,
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    }
+  }
+}

--- a/python-examples/e-commerce-scrapingcourse/README.md
+++ b/python-examples/e-commerce-scrapingcourse/README.md
@@ -1,0 +1,172 @@
+# E-Commerce Product Scraper
+
+E-commerce scraping automation that extracts product information from an online store with pagination support.
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# Using uv (recommended)
+uv sync
+
+# Using pip
+pip install -e .
+```
+
+
+### Run an API
+
+```bash
+# Using uv
+uv run intuned run api <api-name> <parameters>
+
+# Using pip
+intuned run api <api-name> <parameters>
+```
+
+#### Example: List Products
+
+```bash
+# List products with default page limit (50)
+uv run intuned run api list
+
+# List products with custom page limit
+uv run intuned run api list '{"limit": 5}'
+```
+
+#### Example: Get Product Details
+
+```bash
+# Get details for a specific product
+uv run intuned run api details '{"name": "Product Name", "detailsUrl": "https://www.scrapingcourse.com/ecommerce/product/example"}'
+```
+
+### Deploy project
+```bash
+# Using uv
+uv run intuned deploy
+
+# Using pip
+intuned deploy
+```
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── api/                      # Your API endpoints
+│   ├── list.py              # API to scrape product list with pagination
+│   └── details.py           # API to scrape detailed product information
+├── utils/                    # Utility files
+│   └── types_and_schemas.py # Python types and Pydantic models
+└── Intuned.json              # Intuned project configuration file
+```
+
+
+## APIs
+
+### `list` - Product List Scraper
+
+Scrapes products from the e-commerce store with pagination support.
+
+**Parameters:**
+- `limit` (optional): Maximum number of pages to scrape (default: 50)
+
+**Returns:**
+List of products with:
+- `name`: Product name
+- `detailsUrl`: URL to product details page
+
+**Features:**
+- Automatic pagination handling
+- Triggers `details` API for each product using `extend_payload`
+- Configurable page limit
+
+### `details` - Product Details Scraper
+
+Scrapes detailed information for a specific product.
+
+**Parameters:**
+- `name`: Product name
+- `detailsUrl`: URL to the product details page
+
+**Returns:**
+Product details object with:
+- `name`: Product name
+- `price`: Product price
+- `sku`: Stock Keeping Unit
+- `category`: Product category
+- `shortDescription`: Brief product description
+- `fullDescription`: Complete product description
+- `imageAttachments`: List of product images (uploaded to S3)
+- `availableSizes`: List of available sizes
+- `availableColors`: List of available colors
+- `variants`: List of product variants with stock information
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API
+    "enabled": false
+  },
+
+  // Auth session settings
+  "authSessions": {
+    // Auth sessions are not used in this project
+    "enabled": false
+  },
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  },
+
+  // Default job configuration
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        // Number of concurrent API calls within the job
+        "maxConcurrentRequests": 2,
+        // Retry configuration
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    }
+  }
+}
+```
+
+## Using `intuned_browser` SDK
+
+This project uses the Intuned browser SDK for enhanced reliability:
+
+- **`go_to_url`**: Navigate to URLs with automatic retries and intelligent timeout detection
+- **`save_file_to_s3`**: Automatically upload images and files to S3 storage
+- **`extend_payload`**: Trigger additional API calls dynamically (used to trigger `details` API for each product)
+
+For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).

--- a/python-examples/e-commerce-scrapingcourse/api/details.py
+++ b/python-examples/e-commerce-scrapingcourse/api/details.py
@@ -1,0 +1,178 @@
+from playwright.async_api import Page
+from typing import List, Optional
+from intuned_browser import go_to_url, save_file_to_s3, Attachment
+import json
+import re
+
+from utils.types_and_schemas import (
+    ProductDetails,
+    ProductVariant,
+    DetailsSchema,
+)
+
+
+async def get_product_images(page: Page) -> List[Attachment]:
+    # Extract all product images from the gallery
+    image_elements = await page.locator(".woocommerce-product-gallery__image img").all()
+
+    images: List[Attachment] = []
+    for img_element in image_elements:
+        img_src = await img_element.get_attribute("src")
+        if img_src:
+            uploaded_image = await save_file_to_s3(
+                trigger=img_src,
+                page=page,
+            )
+            images.append(uploaded_image)
+    return images
+
+
+async def get_available_sizes(page: Page) -> List[str]:
+    # Extract available sizes from the size dropdown
+    size_options = await page.locator("#size option[value]:not([value=''])").all()
+
+    sizes: List[str] = []
+    for option in size_options:
+        size_value = await option.get_attribute("value")
+        if size_value:
+            sizes.append(size_value)
+    return sizes
+
+
+async def get_available_colors(page: Page) -> List[str]:
+    # Extract available colors from the color dropdown
+    color_options = await page.locator("#color option[value]:not([value=''])").all()
+
+    colors: List[str] = []
+    for option in color_options:
+        color_value = await option.get_attribute("value")
+        if color_value:
+            colors.append(color_value)
+    return colors
+
+
+async def get_product_variants(page: Page) -> List[ProductVariant]:
+    # Extract product variants from the JSON data in the form
+    # WooCommerce stores all variant information in a data attribute
+    variants_form = page.locator("form.variations_form")
+    variants_data = await variants_form.get_attribute("data-product_variations")
+
+    variants: List[ProductVariant] = []
+
+    if not variants_data:
+        return variants
+
+    try:
+        # Parse the JSON data containing all product variants
+        variants_json = json.loads(variants_data)
+
+        for variant in variants_json:
+            # Extract availability text and parse stock number
+            availability_html = variant.get("availability_html", "")
+            stock_match = re.search(r"(\d+)\s+in stock", availability_html)
+            stock = int(stock_match.group(1)) if stock_match else 0
+
+            variants.append(
+                ProductVariant(
+                    sku=variant.get("sku", ""),
+                    size=variant.get("attributes", {}).get("attribute_size", ""),
+                    color=variant.get("attributes", {}).get("attribute_color", ""),
+                    availability="In Stock"
+                    if variant.get("is_in_stock")
+                    else "Out of Stock",
+                    stock=stock,
+                )
+            )
+    except Exception as error:
+        print(f"Failed to parse variants data: {error}")
+
+    return variants
+
+
+async def extract_product_details(page: Page, params: DetailsSchema) -> ProductDetails:
+    # Wait for the main product container to load
+    product_container = page.locator("div[id^='product']")
+    await product_container.wait_for(state="visible")
+
+    # Extract the product title
+    title_element = page.locator("h1.product_title")
+    name = await title_element.text_content() or params.name
+
+    # Extract the price
+    price_element = page.locator(".summary .price .woocommerce-Price-amount").first
+    price = await price_element.text_content()
+
+    # Extract id
+    id_element = page.locator(".sku_wrapper .id")
+    id = await id_element.text_content() or ""
+
+    # Extract category
+    category_element = page.locator(".posted_in a")
+    category = await category_element.text_content() or ""
+
+    # Extract short description (the brief summary under the title)
+    short_desc_element = page.locator(".woocommerce-product-details__short-description")
+    short_description = await short_desc_element.text_content() or ""
+
+    # Extract full description from the Description tab
+    full_desc_element = page.locator("#tab-description p")
+    full_description_parts = await full_desc_element.all_text_contents()
+    full_description = "\n".join(full_description_parts).strip()
+
+    # Extract images, sizes, colors, and variants
+    image_attachments = await get_product_images(page)
+    available_sizes = await get_available_sizes(page)
+    available_colors = await get_available_colors(page)
+    variants = await get_product_variants(page)
+
+    return ProductDetails(
+        # data from params
+        detailsUrl=str(params.detailsUrl),
+        # New detailed information
+        name=name.strip(),
+        price=price.strip() if price else "",
+        id=id.strip(),
+        category=category.strip(),
+        shortDescription=short_description.strip(),
+        fullDescription=full_description,
+        imageAttachments=image_attachments,
+        availableSizes=available_sizes,
+        availableColors=available_colors,
+        variants=variants,
+    )
+
+
+async def handler(
+    page: Page,
+    params: Optional[dict] = None,
+    **_kwargs,
+) -> ProductDetails:
+    if params is None:
+        raise ValueError("Params are required for this handler")
+
+    # Validate params using pydantic model
+    validated_params = DetailsSchema(**params)
+
+    # Navigate to the product detail page using the URL from params
+    # Using intuned SDK's goToUrl with enhanced reliability features:
+    # - Automatic retries with exponential backoff
+    # - Intelligent timeout detection
+    # - Optional AI-powered loading verification
+    await go_to_url(
+        page=page,
+        url=str(validated_params.detailsUrl),
+        wait_for_load_state="networkidle",
+        # The SDK handles retries and timeout management automatically
+    )
+
+    # Original Playwright navigation (commented out):
+    # - Basic navigation without retry logic
+    # - Manual waitUntil specification required
+    # - No automatic error recovery
+    # await page.goto(str(validated_params.detailsUrl), wait_until="networkidle")
+
+    # Extract all detailed product information
+    product_details = await extract_product_details(page, validated_params)
+
+    # Return the complete product details
+    return product_details

--- a/python-examples/e-commerce-scrapingcourse/api/list.py
+++ b/python-examples/e-commerce-scrapingcourse/api/list.py
@@ -1,0 +1,137 @@
+from playwright.async_api import Page
+from typing import TypedDict, List, Optional
+from runtime_helpers import extend_payload
+from intuned_browser import go_to_url
+
+from utils.types_and_schemas import ListSchema
+
+
+class Product(TypedDict):
+    name: str
+    detailsUrl: str
+
+
+async def has_next_page(page: Page) -> bool:
+    # Look for the "next" button in the pagination
+    # The next button has class "next page-numbers" and is a link (not disabled)
+    next_button = page.locator("a.next.page-numbers")
+
+    # Check if the next button exists on the page
+    # If it exists, there is a next page available
+    count = await next_button.count()
+
+    return count > 0
+
+
+async def extract_products_from_page(page: Page) -> List[Product]:
+    # Wait for the product list container to be visible on the page
+    # This ensures the page has fully loaded before we try to scrape
+    products_container = page.locator("#product-list")
+    await products_container.wait_for(state="visible")
+
+    # Find all product items within the container
+    # Each product is represented by an <li> element with data-products="item"
+    product_elements = await products_container.locator(
+        "li[data-products='item']"
+    ).all()
+
+    # Array to store all extracted product data
+    products: List[Product] = []
+
+    # Loop through each product element to extract its information
+    for product_element in product_elements:
+        try:
+            # Extract the product name from the h2 heading
+            name_element = product_element.locator("h2.product-name")
+            name = await name_element.text_content()
+
+            # Extract the product details URL from the main product link
+            link_element = product_element.locator("a.woocommerce-LoopProduct-link")
+            details_url = await link_element.get_attribute("href")
+
+            # Add the product to products list
+            if name and details_url:
+                product: Product = {
+                    "name": name.strip(),
+                    "detailsUrl": details_url.strip(),
+                }
+
+                products.append(product)
+                # extend the payload to trigger the details API
+                extend_payload(
+                    {
+                        "api": "details",
+                        "parameters": product,
+                    }
+                )
+        except Exception as error:
+            # If extraction fails for a single product, log the error but continue with others
+            print(f"Failed to extract product data: {error}")
+            continue
+
+    return products
+
+
+async def navigate_to_next_page(page: Page) -> None:
+    # Click the next page button to navigate to the next page
+    # .first() because this locator resolves to multiple elements on the page
+    next_button = page.locator("a.next.page-numbers").first
+    await next_button.click()
+
+    # Wait for the page to load after clicking next
+    # Wait for the product list to be visible again
+    await page.locator("#product-list").wait_for(state="visible")
+
+
+async def handler(
+    page: Page,
+    params: Optional[dict] = None,
+    **_kwargs,
+) -> List[Product]:
+    # Get the page limit from params, default to 50 if not provided
+    if params is None:
+        params = {}
+
+    validated_params = ListSchema(**params)
+    page_limit = validated_params.limit or 50
+
+    # Navigate to the e-commerce website
+    await go_to_url(
+        page=page,
+        url="https://www.scrapingcourse.com/ecommerce/",
+    )
+
+    # Array to store all products from all pages
+    all_products: List[Product] = []
+    current_page = 1
+
+    # Loop through all pages until there are no more pages or limit is reached
+    while True:
+        print(f"Scraping page {current_page}...")
+
+        # Extract all products from the current page
+        products = await extract_products_from_page(page)
+
+        # Add the products from this page to our complete list
+        all_products.extend(products)
+
+        # Check if we've reached the page limit
+        if current_page >= page_limit:
+            print(f"Reached page limit of {page_limit} pages")
+            break
+
+        # Check if there's a next page available
+        has_next = await has_next_page(page)
+
+        if not has_next:
+            # No more pages - exit the loop
+            print("No more pages to scrape")
+            break
+
+        # Navigate to the next page
+        await navigate_to_next_page(page)
+
+        current_page += 1
+
+    # Return the scraped products
+    return all_products

--- a/python-examples/e-commerce-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-scrapingcourse/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ecommerce"
+version = "0.0.1"
+description = "E-commerce automation that extracts product details from a list of products"
+authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
+requires-python = ">=3.12,<3.13"
+readme = "README.md"
+keywords = [
+    "Python",
+    "intuned-browser-sdk",
+]
+dependencies = [
+    "playwright==1.56",
+    "intuned-runtime==1.3.12",
+    "intuned-browser==0.1.9",
+    "pydantic==2.10.6",
+]
+
+[tool.uv]
+package = false

--- a/python-examples/e-commerce-scrapingcourse/utils/types_and_schemas.py
+++ b/python-examples/e-commerce-scrapingcourse/utils/types_and_schemas.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel, HttpUrl, field_validator
+from typing import List, Optional
+from intuned_browser import Attachment
+
+
+class ListSchema(BaseModel):
+    limit: Optional[int] = None
+
+
+class DetailsSchema(BaseModel):
+    name: str
+    detailsUrl: HttpUrl
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not v or len(v.strip()) < 1:
+            raise ValueError("Product name is required")
+        return v
+
+
+class ProductVariant(BaseModel):
+    sku: str
+    size: str
+    color: str
+    availability: str
+    stock: int
+
+
+class ProductDetails(BaseModel):
+    name: str
+    detailsUrl: str
+    price: str
+    id: str
+    category: str
+    shortDescription: str
+    fullDescription: str
+    availableSizes: List[str]
+    availableColors: List[str]
+    variants: List[ProductVariant]
+    imageAttachments: List[Attachment]

--- a/python-examples/rpa-auth-example/api/book-consultations.py
+++ b/python-examples/rpa-auth-example/api/book-consultations.py
@@ -49,97 +49,59 @@ async def automation(
     params: dict | None = None,
     context: BrowserContext | None = None,
     **_kwargs,
-):
-    try:
-        # Set the browser viewport size to 1080x720 pixels
-        # This ensures consistent rendering across different devices and screen sizes
-        # Some websites may display different layouts or elements based on viewport size
-        await page.set_viewport_size({"width": 1080, "height": 720})
+) -> dict:
+    # Set the browser viewport size to 1080x720 pixels
+    # This ensures consistent rendering across different devices and screen sizes
+    # Some websites may display different layouts or elements based on viewport size
+    await page.set_viewport_size({"width": 1080, "height": 720})
 
-        # Step 1: Validate input parameters using schema
-        # This ensures all required fields are present and properly formatted
-        if params is None:
-            return {
-                "success": False,
-                "message": "Invalid parameters provided",
-                "errors": ["Params are required"],
-            }
+    # Step 1: Validate input parameters using schema
+    # This ensures all required fields are present and properly formatted
+    if params is None:
+        raise ValueError("Params are required")
 
-        try:
-            validated_params = BookConsultationSchema(**params)
-        except Exception as validation_error:
-            # Return error if validation fails
-            return {
-                "success": False,
-                "message": "Invalid parameters provided",
-                "errors": str(validation_error),
-            }
+    validated_params = BookConsultationSchema(**params)
 
-        # Extract validated parameters
-        name = validated_params.name
-        email = validated_params.email
-        phone = validated_params.phone
-        date = validated_params.date
-        time = validated_params.time
-        topic = validated_params.topic
+    # Extract validated parameters
+    name = validated_params.name
+    email = validated_params.email
+    phone = validated_params.phone
+    date = validated_params.date
+    time = validated_params.time
+    topic = validated_params.topic
 
-        # Step 2: Navigate to the consultation booking page
-        sandboxed_url = "https://sandbox.intuned.dev/consultations-auth/book"
+    # Step 2: Navigate to the consultation booking page
+    await go_to_url(
+        page=page,
+        url="https://sandbox.intuned.dev/consultations-auth/book",
+    )
 
-        # Using intuned SDK's goToUrl with enhanced reliability features:
-        # - Automatic retries with exponential backoff
-        # - Intelligent timeout detection
-        # - Optional AI-powered loading verification
-        await go_to_url(
-            page=page,
-            url=sandboxed_url,
-            # waitForLoadState defaults to "load", but you can specify "networkidle" or "domcontentloaded"
-            # The SDK handles retries and timeout management automatically
-        )
+    # Step 3: Fill in personal information fields
+    await fill_personal_information(page, name, email, phone)
 
-        # Original Playwright navigation (commented out):
-        # - Basic navigation without retry logic
-        # - Manual timeout handling required
-        # - No automatic loading state verification
-        # await page.goto("https://sandbox.intuned.dev/consultations-auth/book", wait_until="networkidle")
+    # Step 4: Fill in scheduling information
+    await fill_scheduling_information(page, date, time)
 
-        # Step 3: Fill in personal information fields
-        await fill_personal_information(page, name, email, phone)
+    # Step 5: Select the consultation topic from dropdown
+    await select_topic(page, topic)
 
-        # Step 4: Fill in scheduling information
-        await fill_scheduling_information(page, date, time)
+    # Step 6: Submit the booking form and wait for confirmation
+    await submit_booking_form(page)
 
-        # Step 5: Select the consultation topic from dropdown
-        await select_topic(page, topic)
+    # Step 7: Wait for the success modal to appear
+    # This confirms the booking was processed
+    await wait_for_success_modal(page)
 
-        # Step 6: Submit the booking form and wait for confirmation
-        await submit_booking_form(page)
+    # Step 8: Verify the success message is displayed
+    is_success = await verify_success_message(page)
 
-        # Step 7: Wait for the success modal to appear
-        # This confirms the booking was processed
-        await wait_for_success_modal(page)
-
-        # Step 8: Verify the success message is displayed
-        is_success = await verify_success_message(page)
-
-        # Step 9: Return success response with booking details
-        return {
-            "success": is_success,
-            "date": date,
-            "message": (
-                f"Consultation successfully booked for {date} at {time}"
-                if is_success
-                else "Booking completed but success confirmation unclear"
-            ),
-        }
-    except Exception as error:
-        # Handle any errors that occur during the booking process
-        error_message = str(error)
-
-        # Return error response instead of throwing
-        # This makes it easier for the calling code to handle failures
-        return {
-            "success": False,
-            "message": "Failed to complete booking",
-            "error": error_message,
-        }
+    # Step 9: Return booking details
+    return {
+        "success": is_success,
+        "date": date,
+        "message": (
+            f"Consultation successfully booked for {date} at {time}"
+            if is_success
+            else "Booking completed but success confirmation unclear"
+        ),
+    }

--- a/python-examples/rpa-auth-example/api/get-consultations-by-email.py
+++ b/python-examples/rpa-auth-example/api/get-consultations-by-email.py
@@ -1,25 +1,8 @@
 from playwright.async_api import Page, BrowserContext
-from typing import List, Union, TypedDict
+from typing import List
 from intuned_browser import go_to_url
 
 from utils.types_and_schemas import GetConsultationsByEmailSchema, Consultation
-
-
-class SuccessResponse(TypedDict):
-    success: bool
-    total: int
-    consultations: List[dict]
-
-
-class ErrorResponse(TypedDict):
-    success: bool
-    total: int
-    consultations: List
-    message: str
-    error: str
-
-
-HandlerResponse = Union[SuccessResponse, ErrorResponse]
 
 
 async def search_by_email(page: Page, email: str):
@@ -105,56 +88,37 @@ async def automation(
     params: dict | None = None,
     context: BrowserContext | None = None,
     **_kwargs,
-) -> HandlerResponse:
-    try:
-        if params is None:
-            raise ValueError("Params are required for this automation")
+) -> List[Consultation]:
+    if params is None:
+        raise ValueError("Params are required for this automation")
 
-        # Validate params using pydantic model
-        validated_params = GetConsultationsByEmailSchema(**params)
+    # Validate params using pydantic model
+    validated_params = GetConsultationsByEmailSchema(**params)
 
-        # Step 1: Navigate to the consultations list page
-        # waitUntil: "networkidle" ensures all consultations are loaded
-        await go_to_url(
-            page=page,
-            url="https://sandbox.intuned.dev/consultations-auth/list",
-            wait_for_load_state="networkidle",
-        )
+    # Step 1: Navigate to the consultations list page
+    # waitUntil: "networkidle" ensures all consultations are loaded
+    await go_to_url(
+        page=page,
+        url="https://sandbox.intuned.dev/consultations-auth/list",
+        wait_for_load_state="networkidle",
+    )
 
-        # Step 2: Wait for the consultations list container to be visible
-        # This ensures the page has loaded before we try to extract data
-        consultations_list = page.locator("#consultations-list")
-        await consultations_list.wait_for(state="visible")
+    # Step 2: Wait for the consultations list container to be visible
+    # This ensures the page has loaded before we try to extract data
+    consultations_list = page.locator("#consultations-list")
+    await consultations_list.wait_for(state="visible")
 
-        # Step 3: Search by email
-        await search_by_email(page, validated_params.email)
+    # Step 3: Search by email
+    await search_by_email(page, validated_params.email)
 
-        # Step 4: Find all consultation items on the page
-        # Each consultation item has the class "consultation-item"
-        consultation_items = await find_consultation_items(page)
+    # Step 4: Find all consultation items on the page
+    # Each consultation item has the class "consultation-item"
+    consultation_items = await find_consultation_items(page)
 
-        # Step 5: Extract data from each consultation item
-        consultations = await extract_consultations_data(consultation_items)
+    # Step 5: Extract data from each consultation item
+    consultations = await extract_consultations_data(consultation_items)
 
-        # Step 6: Return all extracted consultations
-        print(f"Successfully extracted {len(consultations)} consultations")
+    # Step 6: Return all extracted consultations
+    print(f"Successfully extracted {len(consultations)} consultations")
 
-        return {
-            "success": True,
-            "total": len(consultations),
-            "consultations": [c.model_dump() for c in consultations],
-        }
-    except Exception as error:
-        # Handle any errors that occur during the listing process
-        error_message = str(error)
-
-        print(f"Failed to list consultations: {error_message}")
-
-        # Return error response instead of throwing
-        return {
-            "success": False,
-            "total": 0,
-            "consultations": [],
-            "message": f"Failed to list consultations: {error_message}",
-            "error": error_message,
-        }
+    return consultations

--- a/python-examples/rpa-example/api/book-consultations.py
+++ b/python-examples/rpa-example/api/book-consultations.py
@@ -49,97 +49,59 @@ async def automation(
     params: dict | None = None,
     context: BrowserContext | None = None,
     **_kwargs,
-):
-    try:
-        # Set the browser viewport size to 1080x720 pixels
-        # This ensures consistent rendering across different devices and screen sizes
-        # Some websites may display different layouts or elements based on viewport size
-        await page.set_viewport_size({"width": 1080, "height": 720})
+) -> dict:
+    # Set the browser viewport size to 1080x720 pixels
+    # This ensures consistent rendering across different devices and screen sizes
+    # Some websites may display different layouts or elements based on viewport size
+    await page.set_viewport_size({"width": 1080, "height": 720})
 
-        # Step 1: Validate input parameters using schema
-        # This ensures all required fields are present and properly formatted
-        if params is None:
-            return {
-                "success": False,
-                "message": "Invalid parameters provided",
-                "errors": ["Params are required"],
-            }
+    # Step 1: Validate input parameters using schema
+    # This ensures all required fields are present and properly formatted
+    if params is None:
+        raise ValueError("Params are required")
 
-        try:
-            validated_params = BookConsultationSchema(**params)
-        except Exception as validation_error:
-            # Return error if validation fails
-            return {
-                "success": False,
-                "message": "Invalid parameters provided",
-                "errors": str(validation_error),
-            }
+    validated_params = BookConsultationSchema(**params)
 
-        # Extract validated parameters
-        name = validated_params.name
-        email = validated_params.email
-        phone = validated_params.phone
-        date = validated_params.date
-        time = validated_params.time
-        topic = validated_params.topic
+    # Extract validated parameters
+    name = validated_params.name
+    email = validated_params.email
+    phone = validated_params.phone
+    date = validated_params.date
+    time = validated_params.time
+    topic = validated_params.topic
 
-        # Step 2: Navigate to the consultation booking page
-        sandboxed_url = "https://sandbox.intuned.dev/consultations/book"
+    # Step 2: Navigate to the consultation booking page
+    await go_to_url(
+        page=page,
+        url="https://sandbox.intuned.dev/consultations/book",
+    )
 
-        # Using intuned SDK's goToUrl with enhanced reliability features:
-        # - Automatic retries with exponential backoff
-        # - Intelligent timeout detection
-        # - Optional AI-powered loading verification
-        await go_to_url(
-            page=page,
-            url=sandboxed_url,
-            # waitForLoadState defaults to "load", but you can specify "networkidle" or "domcontentloaded"
-            # The SDK handles retries and timeout management automatically
-        )
+    # Step 3: Fill in personal information fields
+    await fill_personal_information(page, name, email, phone)
 
-        # Original Playwright navigation (commented out):
-        # - Basic navigation without retry logic
-        # - Manual timeout handling required
-        # - No automatic loading state verification
-        # await page.goto("https://sandbox.intuned.dev/consultations/book", wait_until="networkidle")
+    # Step 4: Fill in scheduling information
+    await fill_scheduling_information(page, date, time)
 
-        # Step 3: Fill in personal information fields
-        await fill_personal_information(page, name, email, phone)
+    # Step 5: Select the consultation topic from dropdown
+    await select_topic(page, topic)
 
-        # Step 4: Fill in scheduling information
-        await fill_scheduling_information(page, date, time)
+    # Step 6: Submit the booking form and wait for confirmation
+    await submit_booking_form(page)
 
-        # Step 5: Select the consultation topic from dropdown
-        await select_topic(page, topic)
+    # Step 7: Wait for the success modal to appear
+    # This confirms the booking was processed
+    await wait_for_success_modal(page)
 
-        # Step 6: Submit the booking form and wait for confirmation
-        await submit_booking_form(page)
+    # Step 8: Verify the success message is displayed
+    is_success = await verify_success_message(page)
 
-        # Step 7: Wait for the success modal to appear
-        # This confirms the booking was processed
-        await wait_for_success_modal(page)
-
-        # Step 8: Verify the success message is displayed
-        is_success = await verify_success_message(page)
-
-        # Step 9: Return success response with booking details
-        return {
-            "success": is_success,
-            "date": date,
-            "message": (
-                f"Consultation successfully booked for {date} at {time}"
-                if is_success
-                else "Booking completed but success confirmation unclear"
-            ),
-        }
-    except Exception as error:
-        # Handle any errors that occur during the booking process
-        error_message = str(error)
-
-        # Return error response instead of throwing
-        # This makes it easier for the calling code to handle failures
-        return {
-            "success": False,
-            "message": "Failed to complete booking",
-            "error": error_message,
-        }
+    # Step 9: Return booking details
+    return {
+        "success": is_success,
+        "date": date,
+        "message": (
+            f"Consultation successfully booked for {date} at {time}"
+            if is_success
+            else "Booking completed but success confirmation unclear"
+        ),
+    }

--- a/typescript-examples/README.md
+++ b/typescript-examples/README.md
@@ -7,6 +7,9 @@ Intuned sample projects in TypeScript.
 | [quick-recipes](./quick-recipes/) | Quick browser automation recipes |
 | [rpa-example](./rpa-example/) | Consultation booking automation |
 | [rpa-auth-example](./rpa-auth-example/) | Authenticated consultation booking with Auth Sessions |
+| [auth-with-secret-otp](./auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
+| [auth-with-email-otp](./auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
+| [e-commerce-scrapingcourse](./e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
 | [e-commerece-shopify](./e-commerece-shopify/) | Shopify store product scraper |
 | [jsdom-example](./jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving usage examples |

--- a/typescript-examples/README.md
+++ b/typescript-examples/README.md
@@ -10,6 +10,7 @@ Intuned sample projects in TypeScript.
 | [auth-with-secret-otp](./auth-with-secret-otp/) | Multi-step authentication with TOTP (Time-based OTP) verification |
 | [auth-with-email-otp](./auth-with-email-otp/) | Multi-step authentication with email-based OTP verification |
 | [e-commerce-scrapingcourse](./e-commerce-scrapingcourse/) | E-commerce product scraper with pagination |
+| [e-commerce-auth-scrapingcourse](./e-commerce-auth-scrapingcourse/) | Authenticated e-commerce scraper with Auth Sessions |
 | [e-commerece-shopify](./e-commerece-shopify/) | Shopify store product scraper |
 | [jsdom-example](./jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving usage examples |

--- a/typescript-examples/auth-with-secret-otp/api/list-contracts.ts
+++ b/typescript-examples/auth-with-secret-otp/api/list-contracts.ts
@@ -5,19 +5,6 @@ import { Contract } from "../utils/typesAndSchemas";
 
 interface Params {}
 
-interface SuccessResponse {
-  success: true;
-  contracts: Contract[];
-}
-
-interface ErrorResponse {
-  success: false;
-  message: string;
-  error: string;
-}
-
-type HandlerResponse = SuccessResponse | ErrorResponse;
-
 async function extractContractsFromTable(page: Page): Promise<Contract[]> {
   // Wait for the table to be visible on the page
   // The table is wrapped in a div with rounded-md border classes
@@ -92,31 +79,15 @@ export default async function handler(
   params: Params,
   page: Page,
   context: BrowserContext
-): Promise<HandlerResponse> {
-  try {
-    // Navigate to the contracts list authentication page
-    await goToUrl({
-      page: page,
-      url: "https://sandbox.intuned.dev/list-auth",
-    });
+): Promise<Contract[]> {
+  // Navigate to the contracts list authentication page
+  await goToUrl({
+    page: page,
+    url: "https://sandbox.intuned.dev/list-auth",
+  });
 
-    const contracts = await extractContractsFromTable(page);
+  const contracts = await extractContractsFromTable(page);
 
-    // Return the scraped data
-    return {
-      success: true,
-      contracts: contracts,
-    };
-  } catch (error) {
-    // Handle any errors that occur during the scraping process
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
-    console.error(`Failed to extract contracts: ${errorMessage}`);
-    // Return error response instead of throwing
-    return {
-      success: false,
-      message: "Failed to extract contracts from the page",
-      error: errorMessage,
-    };
-  }
+  // Return the scraped data
+  return contracts;
 }

--- a/typescript-examples/e-commerce-auth-scrapingcourse/Intuned.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/Intuned.json
@@ -1,0 +1,33 @@
+{
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": true,
+    "type": "API"
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        "maxConcurrentRequests": 2,
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    },
+    "testAuthSessionInput": {
+      "username": "admin@example.com",
+      "password": "password"
+    }
+  }
+}

--- a/typescript-examples/e-commerce-auth-scrapingcourse/README.md
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/README.md
@@ -1,0 +1,216 @@
+# E-Commerce Auth Product Scraper
+
+Authenticated e-commerce scraping automation that extracts product information from a protected dashboard using Auth Sessions.
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# npm
+npm install
+
+# yarn
+yarn
+```
+
+> **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
+
+
+### Run an API
+
+```bash
+# npm
+npm run intuned run api <api-name> <parameters>
+
+# yarn
+yarn intuned run api <api-name> <parameters>
+```
+
+#### Example: List Products
+
+```bash
+# List products from authenticated dashboard
+yarn intuned run api list
+```
+
+#### Example: Get Product Details
+
+```bash
+# Get details for a specific product
+yarn intuned run api details '{"name": "Product Name", "detailsUrl": "https://www.scrapingcourse.com/ecommerce/product/example"}'
+```
+
+### Deploy project
+```bash
+# npm
+npm run intuned deploy
+
+# yarn
+yarn intuned deploy
+```
+
+
+## Auth Sessions
+
+This project uses Intuned Auth Sessions to maintain authenticated access to the dashboard. To learn more, check out the [Authenticated Browser Automations: Conceptual Guide](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/authenticated-browser-automations-conceptual-guide).
+
+### Create a new auth session
+```bash
+# npm
+npm run intuned run authsession create <parameters>
+
+# yarn
+yarn intuned run authsession create <parameters>
+
+# Example
+yarn intuned run authsession create '{"username": "admin@example.com", "password": "password"}'
+```
+
+### Update an existing auth session
+```bash
+# npm
+npm run intuned run authsession update <auth-session-id>
+
+# yarn
+yarn intuned run authsession update <auth-session-id>
+```
+
+### Validate an auth session
+```bash
+# npm
+npm run intuned run authsession validate <auth-session-id>
+
+# yarn
+yarn intuned run authsession validate <auth-session-id>
+```
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── api/                      # Your API endpoints
+│   ├── list.ts              # API to scrape product list from dashboard
+│   └── details.ts           # API to scrape detailed product information
+├── auth-sessions/            # Auth session related APIs
+│   ├── check.ts             # API to check if the auth session is still valid
+│   └── create.ts            # API to create/recreate the auth session programmatically
+├── utils/                    # Utility files
+│   └── typeAndSchemas.ts    # TypeScript types and Zod schemas
+└── Intuned.json              # Intuned project configuration file
+```
+
+
+## APIs
+
+### `list` - Product List Scraper
+
+Scrapes products from the authenticated dashboard.
+
+**Parameters:**
+None
+
+**Returns:**
+Array of products with:
+- `name`: Product name
+- `detailsUrl`: URL to product details page
+
+**Features:**
+- Requires authenticated session
+- Automatically navigates to dashboard
+- Triggers `details` API for each product using `extendPayload`
+
+### `details` - Product Details Scraper
+
+Scrapes detailed information for a specific product.
+
+**Parameters:**
+- `name`: Product name
+- `detailsUrl`: URL to the product details page
+
+**Returns:**
+Product details object with:
+- `name`: Product name
+- `price`: Product price
+- `sku`: Stock Keeping Unit
+- `category`: Product category
+- `shortDescription`: Brief product description
+- `fullDescription`: Complete product description
+- `imageAttachments`: Array of product images (uploaded to S3)
+- `availableSizes`: Array of available sizes
+- `availableColors`: Array of available colors
+- `variants`: Array of product variants with stock information
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API
+    "enabled": true
+  },
+
+  // Auth session settings
+  "authSessions": {
+    // Auth sessions are required to access the protected dashboard
+    "enabled": true,
+    // "API" type requires implementing auth-sessions/create.ts
+    "type": "API"
+  },
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  },
+
+  // Default job configuration
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        // Number of concurrent API calls within the job
+        "maxConcurrentRequests": 2,
+        // Retry configuration
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    },
+    // Test credentials for auth session creation
+    "testAuthSessionInput": {
+      "username": "admin@example.com",
+      "password": "password"
+    }
+  }
+}
+```
+
+## Using `@intuned/browser` SDK
+
+This project uses the Intuned browser SDK for enhanced reliability:
+
+- **`goToUrl`**: Navigate to URLs with automatic retries and intelligent timeout detection
+- **`saveFileToS3`**: Automatically upload images and files to S3 storage
+- **`extendPayload`**: Trigger additional API calls dynamically (used to trigger `details` API for each product)
+
+For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).

--- a/typescript-examples/e-commerce-auth-scrapingcourse/____testParameters/create.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/____testParameters/create.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Demo User Login",
+    "value": "{\n    \"username\": \"admin@example.com\",\n    \"password\": \"password\"\n}",
+    "lastUsed": true,
+    "id": "f1a2b3c4-d5e6-4789-a0b1-c2d3e4f5g6h7"
+  }
+]

--- a/typescript-examples/e-commerce-auth-scrapingcourse/api/details.ts
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/api/details.ts
@@ -1,12 +1,12 @@
 import { BrowserContext, Page } from "playwright";
-import { goToUrl, saveFileToS3, type Attachment } from "@intuned/browser";
-
+import { goToUrl, saveFileToS3 } from "@intuned/browser";
+import { Attachment } from "@intuned/browser";
 import {
   ProductDetails,
   ProductVariant,
   DetailsInputSchema,
   detailsSchema,
-} from "../utils/typesAndSchemas";
+} from "../utils/typeAndSchemas";
 
 type Params = DetailsInputSchema;
 
@@ -126,9 +126,9 @@ export async function extractProductDetails(
     .first();
   const price = await priceElement.textContent();
 
-  // Extract ID
-  const idElemnent = page.locator(".sku_wrapper .sku");
-  const id = (await idElemnent.textContent()) || "";
+  // Extract id (Stock Keeping Unit)
+  const idElement = page.locator(".sku_wrapper .sku");
+  const id = (await idElement.textContent()) || "";
 
   // Extract category
   const categoryElement = page.locator(".posted_in a");

--- a/typescript-examples/e-commerce-auth-scrapingcourse/api/list.ts
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/api/list.ts
@@ -1,0 +1,80 @@
+import { BrowserContext, Page } from "playwright";
+import { extendPayload } from "@intuned/runtime";
+import { goToUrl } from "@intuned/browser";
+
+import { ListInputSchema, listSchema } from "../utils/typeAndSchemas";
+
+type Params = ListInputSchema;
+
+interface Product {
+  name: string;
+  detailsUrl: string;
+}
+
+async function extractProductsFromPage(page: Page): Promise<Product[]> {
+  // Wait for the product grid to be visible
+  // This ensures the page has loaded before we try to extract data
+  const productGrid = page.locator("#product-grid");
+  await productGrid.waitFor({ state: "visible" });
+
+  // Find all product items within the grid
+  // Each product is contained in a div with class "product-item"
+  const productItems = await productGrid.locator(".product-item").all();
+
+  // Array to store all extracted product data
+  const products: Product[] = [];
+
+  for (const productItem of productItems) {
+    try {
+      // Extract the product name
+      const nameElement = productItem.locator(".product-name");
+      const name = await nameElement.textContent();
+
+      // Extract the product detail page URL
+      const linkElement = productItem.locator("a");
+      const productUrl = await linkElement.getAttribute("href");
+
+      // Only add the product if all required fields were found
+      if (name && productUrl) {
+        const product = {
+          name: name.trim(),
+          detailsUrl: productUrl.trim(),
+        };
+
+        products.push(product);
+        // extend the payload to trigger the details API
+        extendPayload({
+          api: "details",
+          parameters: product,
+        });
+      }
+    } catch (error) {
+      // If extraction fails for a single product, log it but continue with others
+      console.error("Failed to extract product data:", error);
+      continue;
+    }
+  }
+
+  return products;
+}
+
+export default async function handler(
+  params: Params,
+  page: Page,
+  context: BrowserContext
+): Promise<Product[]> {
+  // Validate input parameters using schema
+  const validatedParams = listSchema.parse(params);
+
+  // Navigate to the dashboard page
+  await goToUrl({
+    page: page,
+    url: "https://www.scrapingcourse.com/dashboard",
+  });
+
+  // Extract all product details from the page
+  const products = await extractProductsFromPage(page);
+
+  // Return all extracted products
+  return products;
+}

--- a/typescript-examples/e-commerce-auth-scrapingcourse/auth-sessions/check.ts
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/auth-sessions/check.ts
@@ -1,0 +1,23 @@
+import { BrowserContext, Page } from "playwright";
+import { goToUrl } from "@intuned/browser";
+
+export default async function check(
+  page: Page,
+  context: BrowserContext
+): Promise<boolean> {
+  // Step 1: Navigate to a protected page (dashboard)
+  await goToUrl({
+    page,
+    url: "https://www.scrapingcourse.com/dashboard",
+  });
+
+  // Step 2: Check if the products grid is visible
+  // The products grid should only be visible on the dashboard if we're logged in
+  // If we were redirected to login, this element won't exist
+  const productsGrid = page.locator("#product-grid");
+  const isSessionValid = await productsGrid.isVisible();
+
+  // Return true if the session is still valid (products grid is visible)
+  // Return false if the session expired (we were redirected to login)
+  return isSessionValid;
+}

--- a/typescript-examples/e-commerce-auth-scrapingcourse/auth-sessions/create.ts
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/auth-sessions/create.ts
@@ -1,0 +1,42 @@
+import { Page, BrowserContext } from "playwright";
+import { goToUrl } from "@intuned/browser";
+
+export interface CreateAuthSessionParams {
+  username: string;
+  password: string;
+}
+
+export default async function* create(
+  params: CreateAuthSessionParams,
+  page: Page,
+  context: BrowserContext
+): AsyncGenerator<unknown, any, string> {
+  // Step 1: Navigate to the login page
+  await goToUrl({
+    page,
+    url: "https://www.scrapingcourse.com/login",
+  });
+
+  // Step 2: Find the email input field and enter the username
+  // The locator finds the element with id="email"
+  const emailInput = page.locator("#email");
+  await emailInput.fill(params.username);
+
+  // Step 3: Find the password input field and enter the password
+  // The locator finds the element with id="password"
+  const passwordInput = page.locator("#password");
+  await passwordInput.fill(params.password);
+
+  // Step 4: Click the submit button to log in
+  // This will submit the login form with the credentials we just entered
+  const submitButton = page.locator("#submit-button");
+  await submitButton.click();
+
+  // Step 5: Verify successful login by checking if the products grid is visible
+  // If the products grid is visible, it means we successfully logged in
+  const productsGrid = page.locator("#product-grid");
+  const isLoggedIn = await productsGrid.isVisible();
+
+  // Return true if login was successful, false otherwise
+  return isLoggedIn;
+}

--- a/typescript-examples/e-commerce-auth-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ecommerce-with-auth",
+  "version": "1.0.0",
+  "description": "Credentials based e-commerce automation that extracts product details from a list of products",
+  "tags": [
+    "intuned-browser-sdk",
+    "intuned-auth-sessions",
+    "intuned-auth-sessions-credentials",
+    "Authenticated"
+  ],
+  "main": "index.js",
+  "scripts": {
+    "intuned": "intuned"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@intuned/browser": "0.1.6",
+    "@intuned/runtime": "1.3.12",
+    "@types/node": "^20.10.3",
+    "playwright": "~1.56.0",
+    "zod": "^3.22.4"
+  }
+}

--- a/typescript-examples/e-commerce-auth-scrapingcourse/utils/typeAndSchemas.ts
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/utils/typeAndSchemas.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { Attachment } from "@intuned/browser";
+
+export const listSchema = z.object({
+  limit: z.number().optional(),
+});
+
+export const detailsSchema = z.object({
+  name: z.string().min(1, "Product name is required"),
+  detailsUrl: z.string().url("Valid product URL is required"),
+});
+
+export type DetailsInputSchema = z.infer<typeof detailsSchema>;
+export type ListInputSchema = z.infer<typeof listSchema>;
+
+export interface ProductVariant {
+  sku: string;
+  size: string;
+  color: string;
+  availability: string;
+  stock: number;
+}
+
+export interface ProductDetails {
+  name: string;
+  detailsUrl: string;
+  price: string;
+  id: string;
+  category: string;
+  shortDescription: string;
+  fullDescription: string;
+  availableSizes: string[];
+  availableColors: string[];
+  variants: ProductVariant[];
+  imageAttachments: Attachment[];
+}

--- a/typescript-examples/e-commerce-scrapingcourse/Intuned.json
+++ b/typescript-examples/e-commerce-scrapingcourse/Intuned.json
@@ -1,0 +1,28 @@
+{
+  "apiAccess": {
+    "enabled": false
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        "maxConcurrentRequests": 2,
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    }
+  }
+}

--- a/typescript-examples/e-commerce-scrapingcourse/README.md
+++ b/typescript-examples/e-commerce-scrapingcourse/README.md
@@ -1,0 +1,174 @@
+# E-Commerce Product Scraper
+
+E-commerce scraping automation that extracts product information from an online store with pagination support.
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# npm
+npm install
+
+# yarn
+yarn
+```
+
+> **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
+
+
+### Run an API
+
+```bash
+# npm
+npm run intuned run api <api-name> <parameters>
+
+# yarn
+yarn intuned run api <api-name> <parameters>
+```
+
+#### Example: List Products
+
+```bash
+# List products with default page limit (50)
+yarn intuned run api list
+
+# List products with custom page limit
+yarn intuned run api list '{"limit": 5}'
+```
+
+#### Example: Get Product Details
+
+```bash
+# Get details for a specific product
+yarn intuned run api details '{"name": "Product Name", "detailsUrl": "https://www.scrapingcourse.com/ecommerce/product/example"}'
+```
+
+### Deploy project
+```bash
+# npm
+npm run intuned deploy
+
+# yarn
+yarn intuned deploy
+```
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── api/                      # Your API endpoints
+│   ├── list.ts              # API to scrape product list with pagination
+│   └── details.ts           # API to scrape detailed product information
+├── utils/                    # Utility files
+│   └── typesAndSchemas.ts   # TypeScript types and Zod schemas
+└── Intuned.json              # Intuned project configuration file
+```
+
+
+## APIs
+
+### `list` - Product List Scraper
+
+Scrapes products from the e-commerce store with pagination support.
+
+**Parameters:**
+- `limit` (optional): Maximum number of pages to scrape (default: 50)
+
+**Returns:**
+Array of products with:
+- `name`: Product name
+- `detailsUrl`: URL to product details page
+
+**Features:**
+- Automatic pagination handling
+- Triggers `details` API for each product using `extendPayload`
+- Configurable page limit
+
+### `details` - Product Details Scraper
+
+Scrapes detailed information for a specific product.
+
+**Parameters:**
+- `name`: Product name
+- `detailsUrl`: URL to the product details page
+
+**Returns:**
+Product details object with:
+- `name`: Product name
+- `price`: Product price
+- `sku`: Stock Keeping Unit
+- `category`: Product category
+- `shortDescription`: Brief product description
+- `fullDescription`: Complete product description
+- `imageAttachments`: Array of product images (uploaded to S3)
+- `availableSizes`: Array of available sizes
+- `availableColors`: Array of available colors
+- `variants`: Array of product variants with stock information
+
+
+## `Intuned.json` Reference
+```jsonc
+{
+  // API access settings
+  "apiAccess": {
+    // Whether to enable consumption through Intuned API
+    "enabled": false
+  },
+
+  // Auth session settings
+  "authSessions": {
+    // Auth sessions are not used in this project
+    "enabled": false
+  },
+
+  // Replication settings
+  "replication": {
+    // The maximum number of concurrent executions allowed via Intuned API
+    "maxConcurrentRequests": 1,
+
+    // The machine size to use for this project
+    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
+    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
+    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
+    "size": "standard"
+  },
+
+  // Default job configuration
+  "metadata": {
+    "defaultJobInput": {
+      "configuration": {
+        // Number of concurrent API calls within the job
+        "maxConcurrentRequests": 2,
+        // Retry configuration
+        "retry": {
+          "maximumAttempts": 3
+        }
+      },
+      "payload": [
+        {
+          "apiName": "list",
+          "parameters": {}
+        }
+      ]
+    }
+  }
+}
+```
+
+## Using `@intuned/browser` SDK
+
+This project uses the Intuned browser SDK for enhanced reliability:
+
+- **`goToUrl`**: Navigate to URLs with automatic retries and intelligent timeout detection
+- **`saveFileToS3`**: Automatically upload images and files to S3 storage
+- **`extendPayload`**: Trigger additional API calls dynamically (used to trigger `details` API for each product)
+
+For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).

--- a/typescript-examples/e-commerce-scrapingcourse/api/details.ts
+++ b/typescript-examples/e-commerce-scrapingcourse/api/details.ts
@@ -1,0 +1,183 @@
+import { BrowserContext, Page } from "playwright";
+import { goToUrl, saveFileToS3, type Attachment } from "@intuned/browser";
+
+import {
+  ProductDetails,
+  ProductVariant,
+  DetailsInputSchema,
+  detailsSchema,
+} from "../utils/typesAndSchemas";
+
+type Params = DetailsInputSchema;
+
+async function getProductImages(page: Page): Promise<Attachment[]> {
+  // Extract all product images from the gallery
+  const imageElements = await page
+    .locator(".woocommerce-product-gallery__image img")
+    .all();
+
+  const images: Attachment[] = [];
+  for (const imgElement of imageElements) {
+    const imgSrc = await imgElement.getAttribute("src");
+    if (imgSrc) {
+      const uploadedImage = await saveFileToS3({
+        trigger: imgSrc,
+        page: page,
+      });
+      images.push(uploadedImage);
+    }
+  }
+  return images;
+}
+
+async function getAvailableSizes(page: Page): Promise<string[]> {
+  // Extract available sizes from the size dropdown
+  const sizeOptions = await page
+    .locator("#size option[value]:not([value=''])")
+    .all();
+
+  const sizes: string[] = [];
+  for (const option of sizeOptions) {
+    const sizeValue = await option.getAttribute("value");
+    if (sizeValue) {
+      sizes.push(sizeValue);
+    }
+  }
+  return sizes;
+}
+
+async function getAvailableColors(page: Page): Promise<string[]> {
+  // Extract available colors from the color dropdown
+  const colorOptions = await page
+    .locator("#color option[value]:not([value=''])")
+    .all();
+
+  const colors: string[] = [];
+  for (const option of colorOptions) {
+    const colorValue = await option.getAttribute("value");
+    if (colorValue) {
+      colors.push(colorValue);
+    }
+  }
+  return colors;
+}
+
+async function getProductVariants(page: Page): Promise<ProductVariant[]> {
+  // Extract product variants from the JSON data in the form
+  // WooCommerce stores all variant information in a data attribute
+  const variantsForm = page.locator("form.variations_form");
+  const variantsData = await variantsForm.getAttribute(
+    "data-product_variations"
+  );
+
+  const variants: ProductVariant[] = [];
+
+  if (!variantsData) {
+    return variants;
+  }
+
+  try {
+    // Parse the JSON data containing all product variants
+    const variantsJson = JSON.parse(variantsData);
+
+    for (const variant of variantsJson) {
+      // Extract availability text and parse stock number
+      const availabilityHtml = variant.availability_html || "";
+      const stockMatch = availabilityHtml.match(/(\d+)\s+in stock/);
+      const stock = stockMatch ? parseInt(stockMatch[1]) : 0;
+
+      variants.push({
+        sku: variant.sku || "",
+        size: variant.attributes?.attribute_size || "",
+        color: variant.attributes?.attribute_color || "",
+        availability: variant.is_in_stock ? "In Stock" : "Out of Stock",
+        stock: stock,
+      });
+    }
+  } catch (error) {
+    console.error("Failed to parse variants data:", error);
+  }
+
+  return variants;
+}
+
+export async function extractProductDetails(
+  page: Page,
+  params: Params
+): Promise<ProductDetails> {
+  // Wait for the main product container to load
+  const productContainer = page.locator("div[id^='product']");
+  await productContainer.waitFor({ state: "visible" });
+
+  // Extract the product title
+  const titleElement = page.locator("h1.product_title");
+  const name = (await titleElement.textContent()) || params.name;
+
+  // Extract the price
+  const priceElement = page
+    .locator(".summary .price .woocommerce-Price-amount")
+    .first();
+  const price = await priceElement.textContent();
+
+  // Extract ID
+  const idElemnent = page.locator(".sku_wrapper .sku");
+  const id = (await idElemnent.textContent()) || "";
+
+  // Extract category
+  const categoryElement = page.locator(".posted_in a");
+  const category = (await categoryElement.textContent()) || "";
+
+  // Extract short description (the brief summary under the title)
+  const shortDescElement = page.locator(
+    ".woocommerce-product-details__short-description"
+  );
+  const shortDescription = (await shortDescElement.textContent()) || "";
+
+  // Extract full description from the Description tab
+  const fullDescElement = page.locator("#tab-description p");
+  const fullDescriptionParts = await fullDescElement.allTextContents();
+  const fullDescription = fullDescriptionParts.join("\n").trim();
+
+  // Extract images, sizes, colors, and variants
+  const imageAttachments = await getProductImages(page);
+  const availableSizes = await getAvailableSizes(page);
+  const availableColors = await getAvailableColors(page);
+  const variants = await getProductVariants(page);
+
+  return {
+    //data from params
+    detailsUrl: params.detailsUrl,
+    // New detailed information
+    name: name.trim(),
+    price: price?.trim() || "",
+    id: id.trim(),
+    category: category.trim(),
+    shortDescription: shortDescription.trim(),
+    fullDescription: fullDescription,
+    imageAttachments,
+    availableSizes,
+    availableColors,
+    variants,
+  };
+}
+
+export default async function handler(
+  params: Params,
+  page: Page,
+  context: BrowserContext
+): Promise<ProductDetails> {
+  // Validate params using Zod schema
+  const validatedParams = detailsSchema.parse(params);
+
+  // Navigate to the product detail page using the URL from params
+  await goToUrl({
+    page: page,
+    url: validatedParams.detailsUrl,
+  });
+
+  // Extract all detailed product information
+  const productDetails = await extractProductDetails(page, validatedParams);
+
+  // Return the complete product details
+  return productDetails;
+}

--- a/typescript-examples/e-commerce-scrapingcourse/api/list.ts
+++ b/typescript-examples/e-commerce-scrapingcourse/api/list.ts
@@ -1,0 +1,143 @@
+import { BrowserContext, Page } from "playwright";
+import { extendPayload } from "@intuned/runtime";
+import { goToUrl } from "@intuned/browser";
+
+import { ListInputSchema, listSchema } from "../utils/typesAndSchemas";
+
+type Params = ListInputSchema;
+
+interface Product {
+  name: string;
+  detailsUrl: string;
+}
+
+async function hasNextPage(page: Page): Promise<boolean> {
+  // Look for the "next" button in the pagination
+  // The next button has class "next page-numbers" and is a link (not disabled)
+  const nextButton = page.locator("a.next.page-numbers");
+
+  // Check if the next button exists on the page
+  // If it exists, there is a next page available
+  const count = await nextButton.count();
+
+  return count > 0;
+}
+
+async function extractProductsFromPage(page: Page): Promise<Product[]> {
+  // Wait for the product list container to be visible on the page
+  // This ensures the page has fully loaded before we try to scrape
+  const productsContainer = page.locator("#product-list");
+  await productsContainer.waitFor({ state: "visible" });
+
+  // Find all product items within the container
+  // Each product is represented by an <li> element with data-products="item"
+  const productElements = await productsContainer
+    .locator("li[data-products='item']")
+    .all();
+
+  // Array to store all extracted product data
+  const products: Product[] = [];
+
+  // Loop through each product element to extract its information
+  for (const productElement of productElements) {
+    try {
+      // Extract the product name from the h2 heading
+      const nameElement = productElement.locator("h2.product-name");
+      const name = await nameElement.textContent();
+
+      // Extract the product details URL from the main product link
+      const linkElement = productElement.locator(
+        "a.woocommerce-LoopProduct-link"
+      );
+      const detailsUrl = await linkElement.getAttribute("href");
+
+      // Add the product to products list
+      if (name && detailsUrl) {
+        const product = {
+          name: name.trim(),
+          detailsUrl: detailsUrl.trim(),
+        };
+
+        products.push(product);
+        // extend the payload to trigger the details API
+        extendPayload({
+          api: "details",
+          parameters: product,
+        });
+      }
+    } catch (error) {
+      // If extraction fails for a single product, log the error but continue with others
+      console.error("Failed to extract product data:", error);
+      continue;
+    }
+  }
+
+  return products;
+}
+
+async function navigateToNextPage(page: Page): Promise<void> {
+  // Click the next page button to navigate to the next page
+  // .first() because this locator resolves to multiple elements on the page
+  const nextButton = page.locator("a.next.page-numbers").first();
+  await nextButton.click();
+
+  // Wait for the page to load after clicking next
+  // Wait for the product list to be visible again
+  await page.locator("#product-list").waitFor({ state: "visible" });
+}
+
+export default async function handler(
+  params: Params,
+  page: Page,
+  context: BrowserContext
+): Promise<Product[]> {
+  // Validate params using Zod schema
+  const validatedParams = listSchema.parse(params);
+
+  // Get the page limit from params, default to 50 if not provided
+  const pageLimit = validatedParams.limit || 50;
+
+  // Navigate to the e-commerce website
+  await goToUrl({
+    page: page,
+    url: "https://www.scrapingcourse.com/ecommerce/",
+  });
+
+  // Array to store all products from all pages
+  let allProducts: Product[] = [];
+  let currentPage = 1;
+
+  // Loop through all pages until there are no more pages or limit is reached
+  while (true) {
+    console.log(`Scraping page ${currentPage}...`);
+
+    // Extract all products from the current page
+    const products = await extractProductsFromPage(page);
+
+    // Add the products from this page to our complete list
+    allProducts = allProducts.concat(products);
+
+    // Check if we've reached the page limit
+    if (currentPage >= pageLimit) {
+      console.log(`Reached page limit of ${pageLimit} pages`);
+      break;
+    }
+
+    // Check if there's a next page available
+    const hasNext = await hasNextPage(page);
+
+    if (!hasNext) {
+      // No more pages - exit the loop
+      console.log("No more pages to scrape");
+      break;
+    }
+
+    // Navigate to the next page
+    await navigateToNextPage(page);
+
+    currentPage++;
+  }
+
+  // Return the scraped products
+  return allProducts;
+}

--- a/typescript-examples/e-commerce-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-scrapingcourse/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ecommerce",
+  "version": "1.0.0",
+  "description": "E-commerce automation that extracts product details from a list of products",
+  "tags": [],
+  "scripts": {
+    "intuned": "intuned"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@intuned/browser": "0.1.6",
+    "@intuned/runtime": "1.3.12",
+    "@types/node": "^20.10.3",
+    "playwright": "~1.56.0",
+    "zod": "^3.22.4"
+  }
+}

--- a/typescript-examples/e-commerce-scrapingcourse/utils/typesAndSchemas.ts
+++ b/typescript-examples/e-commerce-scrapingcourse/utils/typesAndSchemas.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { Attachment } from "@intuned/browser";
+
+export const listSchema = z.object({
+  limit: z.number().optional(),
+});
+
+export const detailsSchema = z.object({
+  name: z.string().min(1, "Product name is required"),
+  detailsUrl: z.string().url("Valid product URL is required"),
+});
+
+export type DetailsInputSchema = z.infer<typeof detailsSchema>;
+export type ListInputSchema = z.infer<typeof listSchema>;
+
+export interface ProductVariant {
+  sku: string;
+  size: string;
+  color: string;
+  availability: string;
+  stock: number;
+}
+
+export interface ProductDetails {
+  name: string;
+  detailsUrl: string;
+  price: string;
+  id: string;
+  category: string;
+  shortDescription: string;
+  fullDescription: string;
+  availableSizes: string[];
+  availableColors: string[];
+  variants: ProductVariant[];
+  imageAttachments: Attachment[];
+}

--- a/typescript-examples/rpa-auth-example/api/book-consultations.ts
+++ b/typescript-examples/rpa-auth-example/api/book-consultations.ts
@@ -60,90 +60,55 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  try {
-    // Set the browser viewport size to 1080x720 pixels
-    // This ensures consistent rendering across different devices and screen sizes
-    // Some websites may display different layouts or elements based on viewport size
-    await page.setViewportSize({
-      width: 1080,
-      height: 720,
-    });
+  // Set the browser viewport size to 1080x720 pixels
+  // This ensures consistent rendering across different devices and screen sizes
+  // Some websites may display different layouts or elements based on viewport size
+  await page.setViewportSize({
+    width: 1080,
+    height: 720,
+  });
 
-    // Step 1: Validate input parameters using schema
-    // This ensures all required fields are present and properly formatted
-    const validatedParams = bookConsultationSchema.safeParse(params);
+  // Step 1: Validate input parameters using schema
+  // This ensures all required fields are present and properly formatted
+  const validatedParams = bookConsultationSchema.parse(params);
 
-    if (!validatedParams.success) {
-      // Return error if validation fails
-      return {
-        success: false,
-        message: "Invalid parameters provided",
-        errors: validatedParams?.error?.errors,
-      };
-    }
+  // Extract validated parameters
+  const { name, email, phone, date, time, topic } = validatedParams;
 
-    // Extract validated parameters
-    const { name, email, phone, date, time, topic } = validatedParams.data;
+  // Step 2: Navigate to the consultation booking page
+  const sandboxedUrl = "https://sandbox.intuned.dev/consultations-auth/book";
+  await goToUrl({
+    page: page,
+    url: sandboxedUrl,
+  });
 
-    // Step 2: Navigate to the consultation booking page
-    const sandboxedUrl = "https://sandbox.intuned.dev/consultations-auth/book";
+  // Step 3: Fill in personal information fields
+  await fillPersonalInformation(page, name, email, phone);
 
-    // Using intuned SDK's goToUrl with enhanced reliability features:
-    // - Automatic retries with exponential backoff
-    // - Intelligent timeout detection
-    // - Optional AI-powered loading verification
-    await goToUrl({
-      page: page,
-      url: sandboxedUrl,
-      // waitForLoadState defaults to "load", but you can specify "networkidle" or "domcontentloaded"
-      // The SDK handles retries and timeout management automatically
-    });
+  // Step 4: Fill in scheduling information
+  await fillSchedulingInformation(page, date, time);
 
-    // Original Playwright navigation (commented out):
-    // - Basic navigation without retry logic
-    // - Manual timeout handling required
-    // - No automatic loading state verification
-    // await page.goto("https://sandbox.intuned.dev/consultations/book", {
-    //   waitUntil: "networkidle",
-    // });
+  // Step 5: Select the consultation topic from dropdown
+  await selectTopic(page, topic);
 
-    // Step 3: Fill in personal information fields
-    await fillPersonalInformation(page, name, email, phone);
+  // Step 6: Submit the booking form and wait for confirmation
+  await submitBookingForm(page);
 
-    // Step 4: Fill in scheduling information
-    await fillSchedulingInformation(page, date, time);
+  // Step 7: Wait for the success modal to appear
+  // This confirms the booking was processed
+  await waitForSuccessModal(page);
 
-    // Step 5: Select the consultation topic from dropdown
-    await selectTopic(page, topic);
+  // Step 8: Verify the success message is displayed
+  const isSuccess = await verifySuccessMessage(page);
 
-    // Step 6: Submit the booking form and wait for confirmation
-    await submitBookingForm(page);
-
-    // Step 7: Wait for the success modal to appear
-    // This confirms the booking was processed
-    await waitForSuccessModal(page);
-
-    // Step 8: Verify the success message is displayed
-    const isSuccess = await verifySuccessMessage(page);
-
-    // Step 9: Return success response with booking details
-    return {
-      success: isSuccess,
-      date: date,
-      message: isSuccess
-        ? `Consultation successfully booked for ${date} at ${time}`
-        : "Booking completed but success confirmation unclear",
-    };
-  } catch (error) {
-    // Handle any errors that occur during the booking process
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
-    // Return error response instead of throwing
-    // This makes it easier for the calling code to handle failures
-    return {
-      success: false,
-      message: "Failed to complete booking",
-      error: errorMessage,
-    };
+  if (!isSuccess) {
+    throw new Error("Booking completed but success confirmation unclear");
   }
+
+  // Step 9: Return booking details
+  return {
+    date: date,
+    time: time,
+    message: `Consultation successfully booked for ${date} at ${time}`,
+  };
 }

--- a/typescript-examples/rpa-example/api/get-consultations-by-email.ts
+++ b/typescript-examples/rpa-example/api/get-consultations-by-email.ts
@@ -9,22 +9,6 @@ import {
 
 type Params = z.infer<typeof getConsultationsByEmailSchema>;
 
-interface SuccessResponse {
-  success: true;
-  total: number;
-  consultations: Consultation[];
-}
-
-interface ErrorResponse {
-  success: false;
-  total: 0;
-  consultations: [];
-  message: string;
-  error: string;
-}
-
-type HandlerResponse = SuccessResponse | ErrorResponse;
-
 async function searchByEmail(page: Page, email: string) {
   const searchInput = page.locator(
     "input[placeholder='Search by name, email, or phone']"
@@ -123,64 +107,33 @@ export default async function handler(
   params: Params,
   page: Page,
   context: BrowserContext
-): Promise<HandlerResponse> {
-  try {
-    // Validate params using Zod schema
-    const validatedParams = getConsultationsByEmailSchema.safeParse(params);
-    if (!validatedParams.success) {
-      return {
-        success: false,
-        total: 0,
-        consultations: [],
-        message: validatedParams.error.message,
-        error: validatedParams.error.message,
-      };
-    }
+): Promise<Consultation[]> {
+  // Validate params using Zod schema
+  const { email } = getConsultationsByEmailSchema.parse(params);
 
-    // Step 1: Navigate to the consultations list page
-    // waitUntil: "networkidle" ensures all consultations are loaded
-    await goToUrl({
-      page: page,
-      url: "https://sandbox.intuned.dev/consultations/list",
-      waitForLoadState: "networkidle",
-    });
+  // Step 1: Navigate to the consultations list page
+  await goToUrl({
+    page: page,
+    url: "https://sandbox.intuned.dev/consultations/list",
+  });
 
-    // Step 2: Wait for the consultations list container to be visible
-    // This ensures the page has loaded before we try to extract data
-    const consultationsList = page.locator("#consultations-list");
-    await consultationsList.waitFor({ state: "visible" });
+  // Step 2: Wait for the consultations list container to be visible
+  // This ensures the page has loaded before we try to extract data
+  const consultationsList = page.locator("#consultations-list");
+  await consultationsList.waitFor({ state: "visible" });
 
-    // Step 3: Search by email
-    await searchByEmail(page, validatedParams.data.email);
+  // Step 3: Search by email
+  await searchByEmail(page, email);
 
-    // Step 4: Find all consultation items on the page
-    // Each consultation item has the class "consultation-item"
-    const consultationItems = await findConsultationItems(page);
+  // Step 4: Find all consultation items on the page
+  // Each consultation item has the class "consultation-item"
+  const consultationItems = await findConsultationItems(page);
 
-    // Step 5: Extract data from each consultation item
-    const consultations = await extractConsultationsData(consultationItems);
+  // Step 5: Extract data from each consultation item
+  const consultations = await extractConsultationsData(consultationItems);
 
-    // Step 6: Return all extracted consultations
-    console.log(`Successfully extracted ${consultations.length} consultations`);
+  // Step 6: Return all extracted consultations
+  console.log(`Successfully extracted ${consultations.length} consultations`);
 
-    return {
-      success: true,
-      total: consultations.length,
-      consultations: consultations,
-    };
-  } catch (error) {
-    // Handle any errors that occur during the listing process
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
-    console.error(`Failed to list consultations: ${errorMessage}`);
-
-    // Return error response instead of throwing
-    return {
-      success: false,
-      total: 0,
-      consultations: [],
-      message: `Failed to list consultations: ${errorMessage}`,
-      error: errorMessage,
-    };
-  }
+  return consultations;
 }


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

