### PR TITLE
Refactor: network interception

### DIFF
--- a/python-examples/network-interception/api/network-interceptor.py
+++ b/python-examples/network-interception/api/network-interceptor.py
@@ -33,8 +33,6 @@ async def login(page: Page, username: str, password: str, login_url: str) -> Non
 
 
 async def intercept_request(request: Request) -> None:
-    global csrf_token
-
     # Replace "graphql" with the URL pattern that contains CSRF tokens on your site
     if "graphql" in request.url and attempt_store.get("csrf_token") is None:
         # Replace "x-csrftoken" with your site's CSRF header name
@@ -52,8 +50,6 @@ async def fetch_with_csrf(
     body: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
 ) -> Any:
-    global csrf_token
-
     # Customize the headers below to match your API requirements
     fetch_script = """
         async (options) => {

--- a/python-examples/network-interception/api/network-interceptor.py
+++ b/python-examples/network-interception/api/network-interceptor.py
@@ -1,10 +1,8 @@
 from playwright.async_api import Page, BrowserContext, Request
 from typing import Optional, Any, Dict
-from intuned_browser import go_to_url
+from intuned_browser import go_to_url, wait_for_network_settled
 from intuned_runtime import attempt_store
 from utils.types_and_schemas import NetworkInterceptorParams, InsureeResponse
-
-attempt_store.set("csrf_token", None)
 
 
 async def login(page: Page, username: str, password: str, login_url: str) -> None:
@@ -19,11 +17,12 @@ async def login(page: Page, username: str, password: str, login_url: str) -> Non
     try:
         print(f"Navigating to login page: {login_url}")
         await go_to_url(page, login_url)
-        await page.wait_for_load_state("networkidle")
         # Replace selectors below with your site's login form selectors
         print(f"Filling login form for user: {username}")
-        await page.locator("input[type='text']").fill(username)
-        await page.locator("input[type='password']").fill(password)
+        await page.locator("input[type='text']").type(username, delay=100)
+        await page.wait_for_timeout(100)
+        await page.locator("input[type='password']").type(password, delay=100)
+        await page.wait_for_timeout(100)
         await page.locator("button[type='submit']").click()
         await page.wait_for_timeout(3000)
         print("Login completed")
@@ -129,7 +128,8 @@ async def automation(
     login_url = (
         params.login_url or url
     )  # URL to the login page, if not provided, use the main URL
-
+    attempt_store.set("csrf_token", None)
+    
     print("Starting network interception automation")
     await login(page, username, password, login_url)
 
@@ -137,9 +137,11 @@ async def automation(
 
     try:
         print(f"Navigating to: {url}")
-        await go_to_url(page, url)
-        await page.wait_for_load_state("networkidle")
-
+        await wait_for_network_settled(
+            page=page,
+            func=lambda: go_to_url(page, url),
+            timeout_s=20,
+        )
         if not attempt_store.get("csrf_token"):
             raise ValueError("No CSRF token found")
 

--- a/typescript-examples/jsdom-example/api/details.ts
+++ b/typescript-examples/jsdom-example/api/details.ts
@@ -50,7 +50,7 @@ function extractProductDetails(html: string, params: Params): ProductDetails {
   // Extract product images - replace selector as needed
   const imageElements = document.querySelectorAll(
     ".woocommerce-product-gallery__image img"
-  );
+      );
   const images: string[] = [];
   imageElements.forEach((img) => {
     const src = img.getAttribute("src");

--- a/typescript-examples/network-interception/api/api-interceptor.ts
+++ b/typescript-examples/network-interception/api/api-interceptor.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import {
   consultationSchema,
   apiInterceptorParamsSchema,
-} from "../utils/typesAndSchemas.js";
+} from "../utils/typesAndSchemas";
 
 type Params = z.infer<typeof apiInterceptorParamsSchema>;
 


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [x] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [x] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [x] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [x] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [x] Main README and language-specific README updated if adding/modifying examples

