### PR TITLE
Fix attachments in native-crawler template

### DIFF
--- a/python-examples/native-crawler/api/crawl.py
+++ b/python-examples/native-crawler/api/crawl.py
@@ -137,13 +137,7 @@ async def automation(
                         page=page,
                         trigger=link,
                     )
-                    attachments.append(
-                        {
-                            "url": link,
-                            "s3_key": uploaded.get_s3_key(),
-                            "signed_url": await uploaded.get_signed_url(),
-                        }
-                    )
+                    attachments.append(uploaded)
                 except Exception as e:
                     print(f"[crawl] Failed to download {link}: {e}")
 

--- a/typescript-examples/native-crawler/api/crawl.ts
+++ b/typescript-examples/native-crawler/api/crawl.ts
@@ -60,7 +60,7 @@ export default async function handler(
   const schema = params.schema;
   const depth = params.depth ?? 0;
 
-  const keyPrefix = `${getJobRunId()}_`;
+  const keyPrefix = `${getJobRunId()}`;
   const normalizedUrl = normalizeUrl(url);
 
   // Store config for child payloads (only on first call)

--- a/typescript-examples/native-crawler/api/crawl.ts
+++ b/typescript-examples/native-crawler/api/crawl.ts
@@ -60,7 +60,7 @@ export default async function handler(
   const schema = params.schema;
   const depth = params.depth ?? 0;
 
-  const keyPrefix = `${getJobRunId()}`;
+  const keyPrefix = `${getJobRunId()}_`;
   const normalizedUrl = normalizeUrl(url);
 
   // Store config for child payloads (only on first call)
@@ -137,11 +137,7 @@ export default async function handler(
             page,
             trigger: link,
           });
-          attachments.push({
-            url: link,
-            s3_key: uploaded.getS3Key(),
-            signed_url: await uploaded.getSignedUrl(),
-          });
+          attachments.push(uploaded);
         } catch (e) {
           console.log(`[crawl] Failed to download ${link}: ${e}`);
         }


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

