### PR TITLE
fix api name

### DIFF
--- a/.github/scripts/validate-templates.sh
+++ b/.github/scripts/validate-templates.sh
@@ -141,6 +141,28 @@ validate_template() {
     fi
 
     # -------------------------------------------
+    # 3c. Check defaultRunPlaygroundInput structure
+    # -------------------------------------------
+    local playground_input
+    playground_input=$(echo "$config" | jq '.metadata.defaultRunPlaygroundInput // empty' 2>/dev/null || echo "")
+
+    if [[ -n "$playground_input" && "$playground_input" != "null" && "$playground_input" != "{}" ]]; then
+        # Check if it uses wrong key "api" instead of "apiName"
+        local has_api_key
+        has_api_key=$(echo "$config" | jq '.metadata.defaultRunPlaygroundInput | has("api")' 2>/dev/null || echo "false")
+        local has_apiName_key
+        has_apiName_key=$(echo "$config" | jq '.metadata.defaultRunPlaygroundInput | has("apiName")' 2>/dev/null || echo "false")
+
+        if [[ "$has_api_key" == "true" ]]; then
+            error "[$template_name] metadata.defaultRunPlaygroundInput uses 'api' key - should be 'apiName'"
+        elif [[ "$has_apiName_key" == "true" ]]; then
+            success "[$template_name] metadata.defaultRunPlaygroundInput uses correct 'apiName' key"
+        else
+            warning "[$template_name] metadata.defaultRunPlaygroundInput is set but missing 'apiName' key"
+        fi
+    fi
+
+    # -------------------------------------------
     # 4. Check authSessions configuration
     # -------------------------------------------
     local auth_enabled

--- a/python-examples/bs4-example/Intuned.jsonc
+++ b/python-examples/bs4-example/Intuned.jsonc
@@ -18,7 +18,7 @@
       "description": "Web scraping example using BeautifulSoup4 for HTML parsing"
     },
     "defaultRunPlaygroundInput": {
-      "api": "list",
+      "apiName": "list",
       "parameters": {
         "url": "https://www.example.com"
       }

--- a/python-examples/captcha-solving-auth-example/Intuned.jsonc
+++ b/python-examples/captcha-solving-auth-example/Intuned.jsonc
@@ -35,7 +35,7 @@
       "description": "E-commerce scraper with captcha solving and auth sessions"
     },
     "defaultRunPlaygroundInput": {
-      "api": "details",
+      "apiName": "details",
       "parameters": {
         "name": "Mach Street Sweatshirt",
         "price": "$62",

--- a/python-examples/e-commerece-category/Intuned.jsonc
+++ b/python-examples/e-commerece-category/Intuned.jsonc
@@ -18,7 +18,7 @@
         "description": "E-commerce category and product scraper"
       },
       "defaultRunPlaygroundInput": {
-        "api": "ecommerece-category",
+        "apiName": "ecommerece-category",
         "parameters": {
           "store_url": "https://www.veja-store.com/en_us/"
         }

--- a/python-examples/e-commerece-shopify/Intuned.jsonc
+++ b/python-examples/e-commerece-shopify/Intuned.jsonc
@@ -18,7 +18,7 @@
         "description": "Shopify store product scraper"
       },
       "defaultRunPlaygroundInput": {
-        "api": "shopify-list",
+        "apiName": "shopify-list",
         "parameters": {
           "store_url": "https://the-outrage.com",
           "max_pages": 10

--- a/python-examples/hyprid-automation/Intuned.jsonc
+++ b/python-examples/hyprid-automation/Intuned.jsonc
@@ -1,7 +1,6 @@
 // For more information, see our Intuned settings reference
 // https://docs.intunedhq.com/docs/05-references/intuned-json
 {
-  "workspaceId": "a51bd78b-4f13-41b6-a55f-38e4b603315b",
   "projectName": "hyprid-automation",
   "apiAccess": {
     "enabled": false

--- a/python-examples/network-interception/Intuned.jsonc
+++ b/python-examples/network-interception/Intuned.jsonc
@@ -18,7 +18,7 @@
       "description": "Network request interception for API data extraction"
     },
     "defaultRunPlaygroundInput": {
-      "api": "api-interceptor",
+      "apiName": "api-interceptor",
       "parameters": {
         "url": "https://example.com/products",
         "api_pattern": "/api/v1/products",

--- a/python-examples/rpa-auth-example/Intuned.jsonc
+++ b/python-examples/rpa-auth-example/Intuned.jsonc
@@ -19,7 +19,7 @@
       "description": "RPA example for booking consultations with auth session support"
     },
     "defaultRunPlaygroundInput": {
-      "api": "book-consultations",
+      "apiName": "book-consultations",
       "parameters": {
         "name": "Foo Bar",
         "email": "foo@bar.com",

--- a/python-examples/rpa-example/Intuned.jsonc
+++ b/python-examples/rpa-example/Intuned.jsonc
@@ -18,7 +18,7 @@
       "description": "RPA example for booking consultations without authentication"
     },
     "defaultRunPlaygroundInput": {
-      "api": "book-consultations",
+      "apiName": "book-consultations",
       "parameters": {
         "name": "Foo Bar",
         "email": "foo@bar.com",

--- a/python-examples/scrapy-example/Intuned.jsonc
+++ b/python-examples/scrapy-example/Intuned.jsonc
@@ -18,7 +18,7 @@
       "description": "Web scraping examples using Scrapy framework"
     },
     "defaultRunPlaygroundInput": {
-      "api": "scrapy-crawler",
+      "apiName": "scrapy-crawler",
       "parameters": {
         "url": "https://quotes.toscrape.com/",
         "max_pages": 10

--- a/typescript-examples/captcha-solving-auth-example/Intuned.jsonc
+++ b/typescript-examples/captcha-solving-auth-example/Intuned.jsonc
@@ -35,7 +35,7 @@
       "description": "E-commerce scraper with captcha solving and auth sessions"
     },
     "defaultRunPlaygroundInput": {
-      "api": "details",
+      "apiName": "details",
       "parameters": {
         "name": "Mach Street Sweatshirt",
         "price": "$62",

--- a/typescript-examples/e-commerece-category/Intuned.jsonc
+++ b/typescript-examples/e-commerece-category/Intuned.jsonc
@@ -16,7 +16,7 @@
       "description": "E-commerce category and product scraper"
     },
     "defaultRunPlaygroundInput": {
-      "api": "ecommerece-category",
+      "apiName": "ecommerece-category",
       "parameters": {
         "store_url": "https://www.example-store.com/"
       }

--- a/typescript-examples/e-commerece-shopify/Intuned.jsonc
+++ b/typescript-examples/e-commerece-shopify/Intuned.jsonc
@@ -18,7 +18,7 @@
       "description": "Shopify store product scraper"
     },
     "defaultRunPlaygroundInput": {
-      "api": "shopify-list",
+      "apiName": "shopify-list",
       "parameters": {
         "store_url": "https://the-outrage.com",
         "maxPages": 10

--- a/typescript-examples/hybrid-automation/Intuned.jsonc
+++ b/typescript-examples/hybrid-automation/Intuned.jsonc
@@ -1,7 +1,6 @@
 // For more information, see our Intuned settings reference
 // https://docs.intunedhq.com/docs/05-references/intuned-json
 {
-  "workspaceId": "a51bd78b-4f13-41b6-a55f-38e4b603315b",
   "projectName": "hybrid-automation-ts",
   "apiAccess": {
     "enabled": false

--- a/typescript-examples/jsdom-example/Intuned.jsonc
+++ b/typescript-examples/jsdom-example/Intuned.jsonc
@@ -18,7 +18,7 @@
       "description": "Web scraping example using JSDOM for HTML parsing"
     },
     "defaultRunPlaygroundInput": {
-      "api": "jsdom-example",
+      "apiName": "jsdom-example",
       "parameters": {
         "url": "https://www.scrapingcourse.com/ecommerce/"
       }

--- a/typescript-examples/network-interception/Intuned.jsonc
+++ b/typescript-examples/network-interception/Intuned.jsonc
@@ -16,7 +16,7 @@
       "description": "Network request interception for API data extraction"
     },
     "defaultRunPlaygroundInput": {
-      "api": "api-interceptor",
+      "apiName": "api-interceptor",
       "parameters": {
         "url": "https://sandbox.intuned.dev/consultations/list",
         "api_pattern": "/rest/v1/consultations",


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

