### PR TITLE
RPA & SDK template fixes

### DIFF
--- a/python-examples/browser-sdk-showcase/.env.example
+++ b/python-examples/browser-sdk-showcase/.env.example
@@ -1,10 +1,1 @@
 INTUNED_API_KEY=your_api_key_here
-ANTHROPIC_API_KEY=your_anthropic_api_key
-OPENAI_API_KEY=your_openai_api_key
-GOOGLE_API_KEY=your_gemini_api_key
-
-
-INTUNED_S3_SECRET_ACCESS_KEY=your_s3_secret_access_key
-INTUNED_S3_ACCESS_KEY_ID=your_s3_access_key
-INTUNED_S3_REGION=region
-INTUNED_S3_BUCKET=bucket_name

--- a/python-examples/browser-sdk-showcase/.parameters/api/ai/extract-structured-data/default.json
+++ b/python-examples/browser-sdk-showcase/.parameters/api/ai/extract-structured-data/default.json
@@ -1,5 +1,2 @@
 {
-  "extract_from_content": true,
-  "extract_from_page": true,
-  "extract_list": true
 }

--- a/python-examples/browser-sdk-showcase/.parameters/api/go-to-url/default.json
+++ b/python-examples/browser-sdk-showcase/.parameters/api/go-to-url/default.json
@@ -1,5 +1,4 @@
 {
-  "wait_for_load_using_ai": true,
   "timeout": 15,
   "retries": 3
 }

--- a/python-examples/browser-sdk-showcase/.parameters/api/upload-file-to-s3/default.json
+++ b/python-examples/browser-sdk-showcase/.parameters/api/upload-file-to-s3/default.json
@@ -1,6 +1,2 @@
 {
-  "bucket": null,
-  "region": null,
-  "access_key": null,
-  "secret_key": null
 }

--- a/python-examples/browser-sdk-showcase/Intuned.jsonc
+++ b/python-examples/browser-sdk-showcase/Intuned.jsonc
@@ -19,6 +19,14 @@
     "template": {
       "name": "browser-sdk-showcase",
       "description": "Showcase of Intuned Browser SDK helper functions for common automation tasks"
+    },
+    "tags": ["browser-sdk", "helpers", "web-scraping", "automation", "examples"],
+    "defaultRunPlaygroundInput": {
+      "apiName": "go-to-url",
+      "parameters": {
+        "timeout": 15,
+        "retries": 3
+      }
     }
   }
 }

--- a/python-examples/browser-sdk-showcase/README.md
+++ b/python-examples/browser-sdk-showcase/README.md
@@ -2,6 +2,7 @@
 
 A comprehensive collection of browser automation helper functions from the Intuned Browser SDK. This project demonstrates various utilities for web scraping, data processing, file handling, and AI-powered operations.
 
+<!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
 Open this project in Intuned by clicking the button below.
@@ -11,6 +12,7 @@ Open this project in Intuned by clicking the button below.
 ## Getting Started
 
 To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
 
 
 ## Development
@@ -25,39 +27,41 @@ uv sync
 After installing dependencies, `intuned` command should be available in your environment.
 
 ### Run an API
+
 ```bash
-# Example: Download a file
+uv run intuned run api click-until-exhausted .parameters/api/click-until-exhausted/default.json
 uv run intuned run api download-file .parameters/api/download-file/default.json
-
-# Example: Navigate to URL
+uv run intuned run api extract-markdown .parameters/api/extract-markdown/default.json
+uv run intuned run api filter-empty-values .parameters/api/filter-empty-values/default.json
 uv run intuned run api go-to-url .parameters/api/go-to-url/default.json
-
-# Example: Save file to S3
-uv run intuned run api save-file-to-s3 .parameters/api/save-file-to-s3/default.json
-
-# Example: Sanitize HTML
+uv run intuned run api process-date .parameters/api/process-date/default.json
+uv run intuned run api resolve-url .parameters/api/resolve-url/default.json
 uv run intuned run api sanitize-html .parameters/api/sanitize-html/default.json
+uv run intuned run api save-file-to-s3 .parameters/api/save-file-to-s3/default.json
+uv run intuned run api scroll-to-load-content .parameters/api/scroll-to-load-content/default.json
+uv run intuned run api upload-file-to-s3 .parameters/api/upload-file-to-s3/default.json
+uv run intuned run api validate-data-using-schema .parameters/api/validate-data-using-schema/default.json
+uv run intuned run api wait-for-dom-settled .parameters/api/wait-for-dom-settled/default.json
+uv run intuned run api wait-for-network-settled .parameters/api/wait-for-network-settled/default.json
+uv run intuned run api ai/extract-structured-data .parameters/api/ai/extract-structured-data/default.json
+uv run intuned run api ai/is-page-loaded .parameters/api/ai/is-page-loaded/default.json
 ```
-
-> **Note:** This project has many API examples. See `.parameters/api/` for all available examples.
 
 ### Deploy project
 ```bash
 uv run intuned deploy
 ```
+<!-- IDE-IGNORE-END -->
 
+### Intuned Browser SDK
 
-
-
-### `intuned-browser`: Intuned Browser SDK
-
-This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+This project uses the Intuned Browser SDK to demonstrate various helper functions for browser automation. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
 
 
 
 
 ## Project Structure
-The project structure is as follows:
+
 ```
 /
 ├── api/                          # Browser SDK helper examples
@@ -78,7 +82,43 @@ The project structure is as follows:
 │   ├── validate-data-using-schema.py   # Validate data with Pydantic schemas
 │   ├── wait-for-dom-settled.py         # Wait for DOM to stabilize
 │   └── wait-for-network-settled.py     # Wait for network requests to settle
-└── Intuned.jsonc                       # Intuned project configuration file
+├── .parameters/                  # Test parameters for APIs
+│   └── api/                      # API parameters folder
+│       ├── ai/                   # AI helpers parameters
+│       │   ├── extract-structured-data/
+│       │   │   └── default.json
+│       │   └── is-page-loaded/
+│       │       └── default.json
+│       ├── click-until-exhausted/
+│       │   └── default.json
+│       ├── download-file/
+│       │   └── default.json
+│       ├── extract-markdown/
+│       │   └── default.json
+│       ├── filter-empty-values/
+│       │   └── default.json
+│       ├── go-to-url/
+│       │   └── default.json
+│       ├── process-date/
+│       │   └── default.json
+│       ├── resolve-url/
+│       │   └── default.json
+│       ├── sanitize-html/
+│       │   └── default.json
+│       ├── save-file-to-s3/
+│       │   └── default.json
+│       ├── scroll-to-load-content/
+│       │   └── default.json
+│       ├── upload-file-to-s3/
+│       │   └── default.json
+│       ├── validate-data-using-schema/
+│       │   └── default.json
+│       ├── wait-for-dom-settled/
+│       │   └── default.json
+│       └── wait-for-network-settled/
+│           └── default.json
+├── Intuned.jsonc                 # Intuned project configuration file
+└── pyproject.toml                # Python project dependencies
 ```
 
 ## SDK Helpers Showcase
@@ -111,48 +151,7 @@ The project structure is as follows:
 See [ai/README.md](./api/ai/README.md) for AI helpers that require API keys and use AI credits.
 
 
-## `Intuned.jsonc` Reference
-```jsonc
-{
-  // Your Intuned workspace ID. 
-  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
-  "workspaceId": "your_workspace_id",
-
-  // The name of your Intuned project. 
-  // Optional - If not provided here, it must be supplied via the command line when deploying.
-  "projectName": "your_project_name",
-
-  // Replication settings
-  "replication": {
-    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
-    // A number of machines equal to this will be allocated to handle API requests.
-    // Not applicable if api access is disabled.
-    "maxConcurrentRequests": 1,
-
-    // The machine size to use for this project. This is applicable for both API requests and jobs.
-    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
-    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
-    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
-    "size": "standard"
-  }
-
-  // API access settings
-  "apiAccess": {
-    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
-    "enabled": true
-  },
-
-  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
-  "headful": false,
-
-  // The region where your Intuned project is hosted.
-  // For a list of available regions, contact support or refer to the documentation.
-  // Optional - Default: "us"
-  "region": "us"
-}
-```
-
-## Documentation
+## Learn More
 
 For detailed documentation on each helper function, visit:
 - [Intuned Browser SDK - Python](https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/)

--- a/python-examples/browser-sdk-showcase/api/ai/extract-structured-data.py
+++ b/python-examples/browser-sdk-showcase/api/ai/extract-structured-data.py
@@ -1,11 +1,14 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/ai/functions/extract_structured_data
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import go_to_url
 from pydantic import BaseModel, Field
 from intuned_browser.ai import extract_structured_data
 
+
 class Params(TypedDict):
-        pass
+    pass
+
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
     class Book(BaseModel):
@@ -14,8 +17,11 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
         description: str | None = Field(default=None, description="Book description")
         in_stock: bool = Field(description="Stock availability")
         rating: str | None = Field(default=None, description="Book rating")
-    await go_to_url(page, 'https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html')
 
+    await go_to_url(
+        page,
+        "https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html",
+    )
 
     # Extract from the Page directly using Pydantic model.
     # You can also extract from a specific locator or by passing TextContentItem.
@@ -26,7 +32,7 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
         model="gpt-5-mini",
         data_schema=Book,  # Pass Pydantic model directly, or use a normal json schema dictionary too.
         prompt="Extract book details from this page",
-        enable_cache=False, # To enable cache, you must run in Intuned context (IDE/CLI) and save the project, with the correct API credentials.
+        enable_cache=False,  # To enable cache, you must run in Intuned context (IDE/CLI) and save the project, with the correct API credentials.
         max_retires=3,
     )
     print(f"Found product: {product['name']} - {product['price']}")

--- a/python-examples/browser-sdk-showcase/api/ai/is-page-loaded.py
+++ b/python-examples/browser-sdk-showcase/api/ai/is-page-loaded.py
@@ -1,20 +1,20 @@
-from playwright.async_api import Page
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/ai/functions/is_page_loaded
 from typing import TypedDict
+from playwright.async_api import Page
 from intuned_browser.ai import is_page_loaded
 
-    
-class Params(TypedDict):
-        pass
 
-async def automation(page: Page, params: Params | None = None, **_kwargs):
+class Params(TypedDict):
+    pass
+
+
+async def automation(page: Page, params: Params, **_kwargs):
     # Wait for page to finish loading
-    await page.goto('https://www.booking.com/')
-    page_loaded = await is_page_loaded(page) # Use AI vision to determine if the page has finished loading.
-    # At this point, the AI has determined if the page has finished loading based on a screenshot taken of the page.
+    await page.goto("https://sandbox.intuned.dev/")
+    page_loaded = await is_page_loaded(page)
     if page_loaded:
         # Continue with scraping or interactions
-        print("Page is fully loaded")
+        print("Page is loaded")
     else:
         # Wait longer or retry
-        print("Page is still loading")
-    return "Done"
+        await page.wait_for_timeout(5000)

--- a/python-examples/browser-sdk-showcase/api/click-until-exhausted.py
+++ b/python-examples/browser-sdk-showcase/api/click-until-exhausted.py
@@ -1,16 +1,16 @@
-from playwright.async_api import Page
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/extract_markdown
 from typing import TypedDict
+from playwright.async_api import Page
 from intuned_browser import click_until_exhausted
-from intuned_browser import go_to_url
-
 class Params(TypedDict):
-        pass
-
-async def automation(page: Page, params: Params | None = None, **_kwargs):
-    await go_to_url(page, "https://careers.qualcomm.com/careers")
-    button_locator = page.locator("xpath=//button[@class='btn btn-sm btn-secondary show-more-positions']")
-    # Click on the button to load more content 5 times.
-    # Check https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/click_until_exhausted for more details.
-    await click_until_exhausted(page=page, button_locator=button_locator, max_clicks=5)
-    # Now content is loaded and visible
-    return "Success"
+    pass
+async def automation(page: Page, params: Params, **_kwargs):
+    await page.goto("https://sandbox.intuned.dev/load-more")
+    load_more_button = page.locator("main main button")  # Select the main button in the main content area.
+    # Click until button disappears or is disabled
+    await click_until_exhausted(
+        page=page,
+        button_locator=load_more_button,
+        max_clicks=20
+    )
+    # Will keep clicking the button until the button disappears or is disabled or the max_clicks is reached.

--- a/python-examples/browser-sdk-showcase/api/download-file.py
+++ b/python-examples/browser-sdk-showcase/api/download-file.py
@@ -1,3 +1,4 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/download_file
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import download_file
@@ -9,19 +10,22 @@ class Params(TypedDict):
 
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
-    timeout = params.get("timeout", 15)
+    timeout = params.get("timeout") if params else 15
     # Direct download from URL
     download = await download_file(page, 'https://intuned-docs-public-images.s3.amazonaws.com/32UP83A_ENG_US.pdf',timeout_s=timeout)
+    print("Result of downloading file from URL:")
     print(download.suggested_filename)
     
     # Download from trigger
     await page.goto("https://sandbox.intuned.dev/pdfs")
     download = await download_file(page, page.locator("xpath=//tbody/tr[1]//*[name()='svg']"))
+    print("Result of downloading file from trigger:")
     print(download.suggested_filename)
     
     # Download from trigger with custom callable function
     await page.goto("https://sandbox.intuned.dev/pdfs")
     download = await download_file(page, lambda page: page.locator("xpath=//tbody/tr[1]//*[name()='svg']").click())
+    print("Result of downloading file from trigger with custom callable function:")
     print(download.suggested_filename)
     
     return download.suggested_filename

--- a/python-examples/browser-sdk-showcase/api/extract-markdown.py
+++ b/python-examples/browser-sdk-showcase/api/extract-markdown.py
@@ -1,3 +1,4 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/extract_markdown
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import extract_markdown
@@ -12,5 +13,6 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     await page.goto("https://books.toscrape.com")
     header_locator = page.locator('h1')
     markdown = await extract_markdown(header_locator) # Extract markdown from the header locator.
+    print("Markdown content of the header:")
     print(markdown)
     return markdown

--- a/python-examples/browser-sdk-showcase/api/filter-empty-values.py
+++ b/python-examples/browser-sdk-showcase/api/filter-empty-values.py
@@ -1,3 +1,4 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/filter_empty_values
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import filter_empty_values
@@ -11,11 +12,14 @@ class Params(TypedDict):
 async def automation(page: Page, params: Params | None = None, **_kwargs):
     # Filter empty values from dictionary
     result1 = filter_empty_values({"a": "", "b": "hello", "c": None})
+    print("Result of filtering empty values from dictionary:")
     print(result1)
     # Filter empty values from list
     result2 = filter_empty_values([1, "", None, [2, ""]])
+    print("Result of filtering empty values from list:")
     print(result2)
     # Filter nested structures
     result3 = filter_empty_values({"users": [{"name": ""}, {"name": "John"}]})
+    print("Result of filtering nested structures:")
     print(result3)
     return result1, result2, result3

--- a/python-examples/browser-sdk-showcase/api/go-to-url.py
+++ b/python-examples/browser-sdk-showcase/api/go-to-url.py
@@ -1,24 +1,29 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/go_to_url
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import go_to_url
-# from intuned_runtime import extend_payload
 
 
 class Params(TypedDict):
-    wait_for_load_using_ai: bool | None
-    timeout: int | None
-    retries: int | None
-    
+    timeout: int
+    retries: int
 
 
-async def automation(page: Page, params: Params | None = None, **_kwargs):
-    wait_for_load_using_ai = params.get("wait_for_load_using_ai", False) #  You must provide an API Key in the environment variables for this to work. Or use Intuned's Gateway.
+async def automation(page: Page, params: Params, **_kwargs):
     timeout = params.get("timeout", 15)
     retries = params.get("retries", 3)
+
     # Navigate to the URL with enhanced reliability and automatic retries.
     # This will wait for the networkidle state more reliably than the default playwright behavior.
-    # Check https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/go_to_url for more details.
-    # wait_for_load_using_ai uses is_page_loaded to determine if the page has finished loading.
-    await go_to_url(page, "https://books.toscrape.com", wait_for_load_using_ai=wait_for_load_using_ai, timeout_s=timeout, retries=retries)
+    # When wait_for_load_using_ai=True, the function uses is_page_loaded under the hood to determine
+    await go_to_url(
+        page,
+        url="https://books.toscrape.com",
+        timeout_s=timeout,
+        retries=retries,
+        wait_for_load_using_ai=True,
+        # Since we are not passing the api_key, the function will use the Intuned AI Gateway.
+    )
+
     # Start your automation here, the page is already loaded and ready to use.
     return "Success"

--- a/python-examples/browser-sdk-showcase/api/process-date.py
+++ b/python-examples/browser-sdk-showcase/api/process-date.py
@@ -1,3 +1,4 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/process_date
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import process_date
@@ -12,22 +13,27 @@ class Params(TypedDict):
 async def automation(page: Page, params: Params | None = None, **_kwargs):
     # Basic date string
     date1 = process_date("22/11/2024")
+    print("Result of processing 22/11/2024:")
     print(date1)  # 2024-11-22 00:00:00
 
     # Single-digit variant
     date2 = process_date("8/16/2019")
+    print("Result of processing 8/16/2019:")
     print(date2)  # 2019-08-16 00:00:00
 
     # Date with time (time is ignored)
     date3 = process_date("12/09/2024 9:00 AM")
+    print("Result of processing 12/09/2024 9:00 AM:")
     print(date3)  # 2024-12-09 00:00:00
 
     # With timezone
     date4 = process_date("10/23/2024 12:06 PM CST")
+    print("Result of processing 10/23/2024 12:06 PM CST:")
     print(date4)  # 2024-10-23 00:00:00
 
     # Full month format
     date5 = process_date("November 14, 2024")
+    print("Result of processing November 14, 2024:")
     print(date5)  # 2024-11-14 00:00:00
 
     return {

--- a/python-examples/browser-sdk-showcase/api/resolve-url.py
+++ b/python-examples/browser-sdk-showcase/api/resolve-url.py
@@ -1,3 +1,4 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/resolve_url
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import resolve_url
@@ -15,6 +16,7 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
         url="/api/users",
         base_url="https://example.com"
     )
+    print("Result of resolving relative URL to absolute URL:")
     print(absolute_url)
     
     # Resolve relative URL from the current page
@@ -23,6 +25,7 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
         url="/blog/intuned-act-3",
         page=page
     )
+    print("Result of resolving relative URL from the current page:")
     print(absolute_url)
     
     # Resolve relative URL from an anchor tag
@@ -30,6 +33,7 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     absolute_url = await resolve_url(
         url=page.locator("a:has-text('Schedule a demo')")
     )
+    print("Result of resolving relative URL from an anchor tag:")
     print(absolute_url)
     
     return "Success"

--- a/python-examples/browser-sdk-showcase/api/sanitize-html.py
+++ b/python-examples/browser-sdk-showcase/api/sanitize-html.py
@@ -1,3 +1,4 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/sanitize_html
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import sanitize_html
@@ -16,5 +17,6 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     first_row = page.locator("ol.row").locator("li").first
     html = await first_row.inner_html()
     sanitized_html = sanitize_html(html, remove_styles=remove_styles, max_attribute_length=max_attribute_length)
+    print("Sanitized HTML:")
     print(sanitized_html)
     return sanitized_html

--- a/python-examples/browser-sdk-showcase/api/save-file-to-s3.py
+++ b/python-examples/browser-sdk-showcase/api/save-file-to-s3.py
@@ -1,41 +1,21 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/save_file_to_s3
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import save_file_to_s3
-from intuned_browser import S3Configs
 from intuned_browser import go_to_url
-# from intuned_runtime import extend_payload
 
 
 class Params(TypedDict):
-    bucket : str | None
-    region : str | None
-    access_key : str | None
-    secret_key : str | None
     pass
 
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
-    # Download a file first
-    bucket = params.get("bucket", None)
-    region = params.get("region", None)
-    access_key = params.get("access_key", None)
-    secret_key = params.get("secret_key", None)
     await go_to_url(page, "https://sandbox.intuned.dev/pdfs")
-    # Configure S3 configuration
-    # Priority: params → environment variables → Intuned's managed S3 bucket (default)
-    s3_config = None
-    if bucket and region and access_key and secret_key:
-        s3_config = S3Configs(
-        bucket_name=bucket,
-        region=region,
-        access_key=access_key,
-        secret_key=secret_key,
-    )
     # Download using a locator
     uploaded_file = await save_file_to_s3(
         page=page,
         trigger=page.locator("xpath=//tbody/tr[1]//*[name()='svg']"),
-        timeout_s=10,
-        configs=s3_config
     )
-    print(f"File uploaded to: {uploaded_file.key}")
+    signed_url = await uploaded_file.get_signed_url()
+    print(f"Signed URL: {signed_url}")
+    return signed_url

--- a/python-examples/browser-sdk-showcase/api/scroll-to-load-content.py
+++ b/python-examples/browser-sdk-showcase/api/scroll-to-load-content.py
@@ -1,19 +1,28 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/scroll_to_load_content
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import scroll_to_load_content
 from intuned_runtime import extend_timeout
 from intuned_browser import go_to_url
 
-class Params(TypedDict):
-    extend_timeout_on_scroll: bool | None  
-    max_scrolls: int | None
 
-async def automation(page: Page, params: Params | None = None, **_kwargs):
+class Params(TypedDict):
+    extend_timeout_on_scroll: bool
+    max_scrolls: int
+
+
+async def automation(page: Page, params: Params, **_kwargs):
     extend_timeout_on_scroll = params.get("extend_timeout_on_scroll", False)
     max_scrolls = params.get("max_scrolls", 10)
-    await go_to_url(page, "https://www.ycombinator.com/companies")
+    await go_to_url(page, "https://sandbox.intuned.dev/infinite-scroll")
     # Scroll through entire page content
     # This will handle infinite scrolls by scrolling the page continuously, and when max_scrolls is reached, it will stop and the data items will be loaded.
-    await scroll_to_load_content(source=page, on_scroll_progress=extend_timeout if extend_timeout_on_scroll else lambda: None, max_scrolls = max_scrolls)
-    # Now all content is loaded and visible
+    # Read about extend_timeout: https://docs.intunedhq.com/docs/05-references/runtime-sdk-python/extend-timeout
+    await scroll_to_load_content(
+        source=page,
+        on_scroll_progress=extend_timeout if extend_timeout_on_scroll else lambda: None,
+        max_scrolls=max_scrolls,
+    )
+    # Will keep scrolling until the page has loaded all content or the max_scrolls is reached.
+
     return "Success"

--- a/python-examples/browser-sdk-showcase/api/upload-file-to-s3.py
+++ b/python-examples/browser-sdk-showcase/api/upload-file-to-s3.py
@@ -1,35 +1,25 @@
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/upload_file_to_s3
 from playwright.async_api import Page
 from typing import TypedDict
 from intuned_browser import upload_file_to_s3
 from intuned_browser import download_file
-from intuned_browser import S3Configs
-# from intuned_runtime import extend_payload
 
 
 class Params(TypedDict):
-    bucket : str | None
-    region : str | None
-    access_key : str | None
-    secret_key : str | None
     pass
 
 
-async def automation(page: Page, params: Params | None = None, **_kwargs):
+async def automation(page: Page, params: Params, **_kwargs):
     # Download a file first
-    bucket = params.get("bucket", None)
-    region = params.get("region", None)
-    access_key = params.get("access_key", None)
-    secret_key = params.get("secret_key", None)
-    download = await download_file(page, "https://intuned-docs-public-images.s3.amazonaws.com/32UP83A_ENG_US.pdf")
-    # Configure S3 configuration
-    # Priority: params → environment variables → Intuned's managed S3 bucket (default)
-    s3_config = None
-    if bucket and region and access_key and secret_key:
-        s3_config = S3Configs(
-        bucket_name=bucket,
-        region=region,
-        access_key=access_key,
-        secret_key=secret_key,
+    download = await download_file(
+        page, "https://intuned-docs-public-images.s3.amazonaws.com/32UP83A_ENG_US.pdf"
     )
-    uploaded_file = await upload_file_to_s3(download, configs=s3_config, file_name_override="myfile.pdf", content_type="application/pdf")
-    print( await uploaded_file.get_signed_url())
+    uploaded_file = await upload_file_to_s3(
+        download,
+        file_name_override="myfile.pdf",
+        content_type="application/pdf",
+    )
+    signed_url = await uploaded_file.get_signed_url()
+    print("Signed URL:")
+    print(signed_url)
+    return signed_url

--- a/python-examples/browser-sdk-showcase/api/validate-data-using-schema.py
+++ b/python-examples/browser-sdk-showcase/api/validate-data-using-schema.py
@@ -1,24 +1,32 @@
-from playwright.async_api import Page
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/validate_data_using_schema
 from typing import TypedDict
+from playwright.async_api import Page
 from intuned_browser import validate_data_using_schema
-
 class Params(TypedDict):
     pass
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
-    user_data = {
-        "name": "John Doe",
-        "email": "john@example.com",
-        "age": 30
+    upload_data = {
+        "file": {
+            "file_name": "documents/report.pdf",
+            "bucket": "my-bucket",
+            "region": "us-east-1",
+            "key": "documents/report.pdf",
+            "endpoint": None,
+            "suggested_file_name": "Monthly Report.pdf",
+            "file_type": "document"
+        },
+        "name": "Test File Upload"
     }
-    user_schema = {
+    upload_schema = {
         "type": "object",
-        "required": ["name", "email", "age"],
+        "required": ["file", "name"],
         "properties": {
-            "name": {"type": "string", "minLength": 1},
-            "email": {"type": "string", "format": "email"},
-            "age": {"type": "number", "minimum": 0}
+            "file": {"type": "attachment"},
+            "name": {"type": "string"}
         }
     }
-    validate_data_using_schema(user_data, user_schema)
-    return "Data validated successfully"
+    validate_data_using_schema(upload_data, upload_schema)
+    # Validation passes with Attachment type, it also validates Pydantic Attachment type.
+    print("Validation passed")
+    return "Validation passed"

--- a/python-examples/browser-sdk-showcase/api/wait-for-dom-settled.py
+++ b/python-examples/browser-sdk-showcase/api/wait-for-dom-settled.py
@@ -1,17 +1,21 @@
-from playwright.async_api import Page
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/wait_for_dom_settled
 from typing import TypedDict
+from playwright.async_api import Page
 from intuned_browser import wait_for_dom_settled
-from intuned_browser import go_to_url
+
+
+# Decorator without arguments (uses settle_duration=0.5, timeout_s=30.0)
+@wait_for_dom_settled
+async def load_more_content(page):
+    await page.locator("main main button").click()
+
 
 class Params(TypedDict):
     pass
 
-@wait_for_dom_settled
-async def load_more_content(page):
-    await page.locator("xpath=//button[@class='btn btn-sm btn-secondary show-more-positions']").click()
-async def automation(page: Page, params: Params | None = None, **_kwargs):
-    await go_to_url(page, "https://careers.qualcomm.com/careers")
+
+async def automation(page: Page, params: Params, **_kwargs):
+    await page.goto("https://sandbox.intuned.dev/load-more")
     # Automatically waits for DOM to settle after clicking
     await load_more_content(page)
     # DOM has settled, new content is loaded
-    return "Success"

--- a/python-examples/browser-sdk-showcase/api/wait-for-network-settled.py
+++ b/python-examples/browser-sdk-showcase/api/wait-for-network-settled.py
@@ -1,17 +1,21 @@
-from playwright.async_api import Page
+# https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/wait_for_network_settled
 from typing import TypedDict
+from playwright.async_api import Page
 from intuned_browser import wait_for_network_settled
-from intuned_browser import go_to_url
+
+
+# Decorator without arguments (uses timeout_s=30, max_inflight_requests=0)
+@wait_for_network_settled
+async def click_load_more(page):
+    await page.locator("main main button").click()
+
 
 class Params(TypedDict):
     pass
 
-@wait_for_network_settled
-async def click_load_more(page: Page):
-    await page.locator("xpath=//button[@class='btn btn-sm btn-secondary show-more-positions']").click()
-    
-async def automation(page: Page, params: Params | None = None, **_kwargs):
-    await go_to_url(page, "https://careers.qualcomm.com/careers")
-    await click_load_more(page) # Automatically waits for network to settle after clicking
+
+async def automation(page: Page, params: Params, **_kwargs):
+    await page.goto("https://sandbox.intuned.dev/load-more")
+    # Automatically waits for network to settle after clicking
+    await click_load_more(page)
     # Network has settled, data is loaded
-    return "Success"

--- a/python-examples/browser-sdk-showcase/pyproject.toml
+++ b/python-examples/browser-sdk-showcase/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "default"
+name = "browser-sdk-showcase"
 version = "0.0.1"
-description = "Empty Intuned project"
+description = "Showcase of Intuned Browser SDK helper functions for common automation tasks"
 authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/python-examples/rpa-example/Intuned.jsonc
+++ b/python-examples/rpa-example/Intuned.jsonc
@@ -17,6 +17,7 @@
       "name": "rpa-example",
       "description": "RPA example for booking consultations without authentication"
     },
+    "tags": ["rpa", "automation", "forms"],
     "defaultRunPlaygroundInput": {
       "apiName": "book-consultations",
       "parameters": {

--- a/python-examples/rpa-example/README.md
+++ b/python-examples/rpa-example/README.md
@@ -1,134 +1,90 @@
-# book-consultations Intuned project
+# RPA Example - Consultation Booking
 
-Booking automation to book a consultation with a consultant and list the consultations
+Booking automation example that demonstrates how to book consultations and retrieve consultation data without authentication.
 
+<!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
 Open this project in Intuned by clicking the button below.
 
 [![Run on Intuned](https://cdn1.intuned.io/button.svg)](https://app.intuned.io?repo=https://github.com/Intuned/cookbook/tree/main/python-examples/rpa-example)
+<!-- IDE-IGNORE-END -->
 
+## What This Example Does
+
+This example demonstrates basic RPA (Robotic Process Automation) workflows:
+
+1. **Book Consultations** - Automates filling out and submitting a consultation booking form with various topics (automation, API integration, data extraction, or other)
+2. **Get Consultations** - Retrieves consultation bookings for a specific email address
+
+<!-- IDE-IGNORE-START -->
 ## Getting Started
 
 To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
-
 
 ## Development
 
 > **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
 
-### Install dependencies
+### Install Dependencies
+
 ```bash
 uv sync
 ```
 
-After installing dependencies, `intuned` command should be available in your environment.
-
 ### Run an API
+
 ```bash
+# Book consultations with different topics
 uv run intuned run api book-consultations .parameters/api/book-consultations/default.json
+uv run intuned run api book-consultations .parameters/api/book-consultations/automation-consultation.json
+uv run intuned run api book-consultations .parameters/api/book-consultations/api-integration-consultation.json
+uv run intuned run api book-consultations .parameters/api/book-consultations/data-extraction-consultation.json
+uv run intuned run api book-consultations .parameters/api/book-consultations/other-topic-consultation.json
+
+# Get consultations by email
 uv run intuned run api get-consultations-by-email .parameters/api/get-consultations-by-email/default.json
 ```
 
-### Deploy project
+### Deploy to Intuned
+
 ```bash
 uv run intuned deploy
 ```
+<!-- IDE-IGNORE-END -->
 
+## `intuned-browser`: Intuned Browser SDK
 
-
-
-### `intuned-browser`: Intuned Browser SDK
-
-This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).
 
 
 
 
 ## Project Structure
-The project structure is as follows:
+
 ```
 /
-├── apis/                     # Your API endpoints 
-│   └── ...   
-├── auth-sessions/            # Auth session related APIs
-│   ├── check.py           # API to check if the auth session is still valid
-│   └── create.py          # API to create/recreate the auth session programmatically
-├── auth-sessions-instances/  # Auth session instances created and used by the CLI
-│   └── ...
-└── Intuned.jsonc              # Intuned project configuration file
+├── api/
+│   ├── book-consultations.py           # Book a consultation
+│   └── get-consultations-by-email.py   # Get consultations for an email
+├── .parameters/
+│   └── api/
+│       ├── book-consultations/
+│       │   ├── default.json                        # Default booking (other topic)
+│       │   ├── automation-consultation.json        # Automation topic
+│       │   ├── api-integration-consultation.json   # API integration topic
+│       │   ├── data-extraction-consultation.json   # Data extraction topic
+│       │   └── other-topic-consultation.json       # Other topic
+│       └── get-consultations-by-email/
+│           └── default.json                        # Get consultations query
+├── utils/
+│   └── types_and_schemas.py           # Type definitions and schemas
+├── Intuned.jsonc                       # Intuned project configuration
+└── pyproject.toml                      # Python dependencies
 ```
 
+## Learn More
 
-## `Intuned.jsonc` Reference
-```jsonc
-{
-  // Your Intuned workspace ID. 
-  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
-  "workspaceId": "your_workspace_id",
-
-  // The name of your Intuned project. 
-  // Optional - If not provided here, it must be supplied via the command line when deploying.
-  "projectName": "your_project_name",
-
-  // Replication settings
-  "replication": {
-    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
-    // A number of machines equal to this will be allocated to handle API requests.
-    // Not applicable if api access is disabled.
-    "maxConcurrentRequests": 1,
-
-    // The machine size to use for this project. This is applicable for both API requests and jobs.
-    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
-    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
-    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
-    "size": "standard"
-  }
-
-  // Auth session settings
-  "authSessions": {
-    // Whether auth sessions are enabled for this project.
-    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
-    "enabled": true,
-
-    // Whether to save Playwright traces for auth session runs.
-    "saveTraces": false,
-
-    // The type of auth session to use.
-    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
-    // "MANUAL" type uses a recorder to manually create the auth session.
-    "type": "API",
-    
-
-    // Recorder start URL for the recorder to navigate to when creating the auth session.
-    // Required if "type" is "MANUAL". Not used if "type" is "API".
-    "startUrl": "https://example.com/login",
-
-    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
-    // Required if "type" is "MANUAL". Not used if "type" is "API".
-    "finishUrl": "https://example.com/dashboard",
-
-    // Recorder browser mode
-    // "fullscreen": Launches the browser in fullscreen mode.
-    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
-    // Only applicable for "MANUAL" type.
-    "browserMode": "fullscreen"
-  }
-  
-  // API access settings
-  "apiAccess": {
-    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
-    // This is required for projects that use auth sessions.
-    "enabled": true
-  },
-
-  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
-  "headful": false,
-
-  // The region where your Intuned project is hosted.
-  // For a list of available regions, contact support or refer to the documentation.
-  // Optional - Default: "us"
-  "region": "us"
-}
-```
-  
+- **Intuned Concepts**: https://docs.intunedhq.com/docs/00-getting-started/introduction
+- **Intuned Browser SDK**: https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview
+- **CLI Documentation**: https://docs.intunedhq.com/docs/05-references/cli

--- a/python-examples/stagehand/Intuned.jsonc
+++ b/python-examples/stagehand/Intuned.jsonc
@@ -16,6 +16,13 @@
     "template": {
       "name": "stagehand",
       "description": "AI-powered browser automation using Stagehand library"
+    },
+    "tags": ["ai", "stagehand", "automation"],
+    "defaultRunPlaygroundInput": {
+      "apiName": "get-books",
+      "parameters": {
+        "category": "Travel"
+      }
     }
   }
 }

--- a/typescript-examples/browser-sdk-showcase/.env.example
+++ b/typescript-examples/browser-sdk-showcase/.env.example
@@ -1,10 +1,1 @@
 INTUNED_API_KEY=your_api_key_here
-ANTHROPIC_API_KEY=your_anthropic_api_key
-OPENAI_API_KEY=your_openai_api_key
-GOOGLE_API_KEY=your_gemini_api_key
-
-
-INTUNED_S3_SECRET_ACCESS_KEY=your_s3_secret_access_key
-INTUNED_S3_ACCESS_KEY_ID=your_s3_access_key
-INTUNED_S3_REGION=region
-INTUNED_S3_BUCKET=bucket_name

--- a/typescript-examples/browser-sdk-showcase/.parameters/api/go-to-url/default.json
+++ b/typescript-examples/browser-sdk-showcase/.parameters/api/go-to-url/default.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://example.com",
-  "waitUntil": "load",
-  "timeout": 30000,
-  "waitForLoadingStateUsingAi": true
+  "timeout": 15000,
+  "retries": 3
 }

--- a/typescript-examples/browser-sdk-showcase/Intuned.jsonc
+++ b/typescript-examples/browser-sdk-showcase/Intuned.jsonc
@@ -18,8 +18,11 @@
       "description": "Showcase of Intuned Browser SDK helper functions for common automation tasks"
     },
     "defaultRunPlaygroundInput": {
-      "apiName": "sample",
-      "parameters": {}
+      "apiName": "go-to-url",
+      "parameters": {
+        "timeout": 15000,
+        "retries": 3
+      }
     }
   }
 }

--- a/typescript-examples/browser-sdk-showcase/README.md
+++ b/typescript-examples/browser-sdk-showcase/README.md
@@ -2,6 +2,7 @@
 
 A comprehensive collection of browser automation helper functions from the Intuned Browser SDK. This project demonstrates various utilities for web scraping, data processing, file handling, and AI-powered operations.
 
+<!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
 Open this project in Intuned by clicking the button below.
@@ -11,6 +12,7 @@ Open this project in Intuned by clicking the button below.
 ## Getting Started
 
 To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
 
 
 ## Development
@@ -28,33 +30,47 @@ yarn
 
 > **_NOTE:_** If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
 
+After installing dependencies, `intuned` command should be available in your environment.
 
 ### Run an API
 
 ```bash
-# Example: Download a file
 # npm
+npm run intuned run api click-until-exhausted .parameters/api/click-until-exhausted/default.json
 npm run intuned run api download-file .parameters/api/download-file/default.json
-
-# yarn
-yarn intuned run api download-file .parameters/api/download-file/default.json
-
-# Example: Extract structured data
-# npm
-npm run intuned run api extract-structured-data .parameters/api/extract-structured-data/default.json
-
-# yarn
-yarn intuned run api extract-structured-data .parameters/api/extract-structured-data/default.json
-
-# Example: Navigate to URL
-# npm
+npm run intuned run api extract-markdown .parameters/api/extract-markdown/default.json
+npm run intuned run api filter-empty-values .parameters/api/filter-empty-values/default.json
 npm run intuned run api go-to-url .parameters/api/go-to-url/default.json
+npm run intuned run api process-date .parameters/api/process-date/default.json
+npm run intuned run api resolve-url .parameters/api/resolve-url/default.json
+npm run intuned run api sanitize-html .parameters/api/sanitize-html/default.json
+npm run intuned run api save-file-to-s3 .parameters/api/save-file-to-s3/default.json
+npm run intuned run api scroll-to-load-content .parameters/api/scroll-to-load-content/default.json
+npm run intuned run api upload-file-to-s3 .parameters/api/upload-file-to-s3/default.json
+npm run intuned run api validate-data-using-schema .parameters/api/validate-data-using-schema/default.json
+npm run intuned run api wait-for-dom-settled .parameters/api/wait-for-dom-settled/default.json
+npm run intuned run api wait-for-network-settled .parameters/api/wait-for-network-settled/default.json
+npm run intuned run api ai/extract-structured-data .parameters/api/ai/extract-structured-data/default.json
+npm run intuned run api ai/is-page-loaded .parameters/api/ai/is-page-loaded/default.json
 
 # yarn
+yarn intuned run api click-until-exhausted .parameters/api/click-until-exhausted/default.json
+yarn intuned run api download-file .parameters/api/download-file/default.json
+yarn intuned run api extract-markdown .parameters/api/extract-markdown/default.json
+yarn intuned run api filter-empty-values .parameters/api/filter-empty-values/default.json
 yarn intuned run api go-to-url .parameters/api/go-to-url/default.json
+yarn intuned run api process-date .parameters/api/process-date/default.json
+yarn intuned run api resolve-url .parameters/api/resolve-url/default.json
+yarn intuned run api sanitize-html .parameters/api/sanitize-html/default.json
+yarn intuned run api save-file-to-s3 .parameters/api/save-file-to-s3/default.json
+yarn intuned run api scroll-to-load-content .parameters/api/scroll-to-load-content/default.json
+yarn intuned run api upload-file-to-s3 .parameters/api/upload-file-to-s3/default.json
+yarn intuned run api validate-data-using-schema .parameters/api/validate-data-using-schema/default.json
+yarn intuned run api wait-for-dom-settled .parameters/api/wait-for-dom-settled/default.json
+yarn intuned run api wait-for-network-settled .parameters/api/wait-for-network-settled/default.json
+yarn intuned run api ai/extract-structured-data .parameters/api/ai/extract-structured-data/default.json
+yarn intuned run api ai/is-page-loaded .parameters/api/ai/is-page-loaded/default.json
 ```
-
-> **Note:** This project has many API examples. See `.parameters/api/` for all available examples.
 
 ### Deploy project
 ```bash
@@ -64,19 +80,17 @@ npm run intuned deploy
 # yarn
 yarn intuned deploy
 ```
+<!-- IDE-IGNORE-END -->
 
+### Intuned Browser SDK
 
-
-
-### `@intuned/browser`: Intuned Browser SDK
-
-This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).
+This project uses the Intuned Browser SDK to demonstrate various helper functions for browser automation. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
 
 
 
 
 ## Project Structure
-The project structure is as follows:
+
 ```
 /
 ├── api/                          # Browser SDK helper examples
@@ -94,10 +108,47 @@ The project structure is as follows:
 │   ├── save-file-to-s3.ts              # Save files to S3
 │   ├── scroll-to-load-content.ts       # Scroll to load dynamic content
 │   ├── upload-file-to-s3.ts            # Upload files to S3
-│   ├── validate-data-using-schema.ts   # Validate data with JSON schemas
+│   ├── validate-data-using-schema.ts   # Validate data with JSON/Zod schemas
 │   ├── wait-for-dom-settled.ts         # Wait for DOM to stabilize
 │   └── wait-for-network-settled.ts     # Wait for network requests to settle
-└── Intuned.jsonc                       # Intuned project configuration file
+├── .parameters/                  # Test parameters for APIs
+│   └── api/                      # API parameters folder
+│       ├── ai/                   # AI helpers parameters
+│       │   ├── extract-structured-data/
+│       │   │   └── default.json
+│       │   └── is-page-loaded/
+│       │       └── default.json
+│       ├── click-until-exhausted/
+│       │   └── default.json
+│       ├── download-file/
+│       │   └── default.json
+│       ├── extract-markdown/
+│       │   └── default.json
+│       ├── filter-empty-values/
+│       │   └── default.json
+│       ├── go-to-url/
+│       │   └── default.json
+│       ├── process-date/
+│       │   └── default.json
+│       ├── resolve-url/
+│       │   └── default.json
+│       ├── sanitize-html/
+│       │   └── default.json
+│       ├── save-file-to-s3/
+│       │   └── default.json
+│       ├── scroll-to-load-content/
+│       │   └── default.json
+│       ├── upload-file-to-s3/
+│       │   └── default.json
+│       ├── validate-data-using-schema/
+│       │   └── default.json
+│       ├── wait-for-dom-settled/
+│       │   └── default.json
+│       └── wait-for-network-settled/
+│           └── default.json
+├── Intuned.jsonc                 # Intuned project configuration file
+├── package.json                  # Node.js project dependencies
+└── tsconfig.json                 # TypeScript configuration
 ```
 
 ## SDK Helpers Showcase
@@ -115,7 +166,7 @@ The project structure is as follows:
 - **extract-markdown**: Convert HTML content to clean markdown
 - **sanitize-html**: Clean and sanitize HTML content
 - **filter-empty-values**: Remove null/empty values from objects
-- **validate-data-using-schema**: Validate data against JSON schemas
+- **validate-data-using-schema**: Validate data against JSON/Zod schemas
 
 ### File Operations
 - **download-file**: Download files from URLs or user interactions
@@ -130,48 +181,7 @@ The project structure is as follows:
 See [ai/README.md](./api/ai/README.md) for AI helpers that require API keys and use AI credits.
 
 
-## `Intuned.jsonc` Reference
-```jsonc
-{
-  // Your Intuned workspace ID. 
-  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
-  "workspaceId": "your_workspace_id",
-
-  // The name of your Intuned project. 
-  // Optional - If not provided here, it must be supplied via the command line when deploying.
-  "projectName": "your_project_name",
-
-  // Replication settings
-  "replication": {
-    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
-    // A number of machines equal to this will be allocated to handle API requests.
-    // Not applicable if api access is disabled.
-    "maxConcurrentRequests": 1,
-
-    // The machine size to use for this project. This is applicable for both API requests and jobs.
-    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
-    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
-    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
-    "size": "standard"
-  }
-
-  // API access settings
-  "apiAccess": {
-    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
-    "enabled": true
-  },
-
-  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
-  "headful": false,
-
-  // The region where your Intuned project is hosted.
-  // For a list of available regions, contact support or refer to the documentation.
-  // Optional - Default: "us"
-  "region": "us"
-}
-```
-
-## Documentation
+## Learn More
 
 For detailed documentation on each helper function, visit:
 - [Intuned Browser SDK - TypeScript](https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/)

--- a/typescript-examples/browser-sdk-showcase/api/ai/extract-structured-data.ts
+++ b/typescript-examples/browser-sdk-showcase/api/ai/extract-structured-data.ts
@@ -1,9 +1,12 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/ai/functions/extractStructuredData
 import { BrowserContext, Page } from "playwright";
 import { goToUrl } from "@intuned/browser";
 import { extractStructuredData } from "@intuned/browser/ai";
 import { z } from "zod";
 
-interface Params {}
+interface Params {
+  // No params needed
+}
 
 const BookSchema = z.object({
   name: z.string().describe("Book title"),

--- a/typescript-examples/browser-sdk-showcase/api/ai/is-page-loaded.ts
+++ b/typescript-examples/browser-sdk-showcase/api/ai/is-page-loaded.ts
@@ -1,3 +1,4 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/ai/functions/isPageLoaded
 import { BrowserContext, Page } from "playwright";
 import { isPageLoaded } from "@intuned/browser/ai";
 
@@ -11,19 +12,15 @@ export default async function handler(
   context: BrowserContext
 ) {
   // Wait for page to finish loading
-  await page.goto("https://www.booking.com/");
+  await page.goto("https://sandbox.intuned.dev/");
   
-  const pageLoaded = await isPageLoaded({ page }); // Use AI vision to determine if the page has finished loading.
-  // At this point, the AI has determined if the page has finished loading based on a screenshot taken of the page.
-  
+  const pageLoaded = await isPageLoaded({ page });
   if (pageLoaded) {
     // Continue with scraping or interactions
-    console.log("Page is fully loaded");
+    console.log("Page is loaded");
   } else {
     // Wait longer or retry
-    console.log("Page is still loading");
+    await page.waitForTimeout(5000);
   }
-  
-  return "Done";
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/click-until-exhausted.ts
+++ b/typescript-examples/browser-sdk-showcase/api/click-until-exhausted.ts
@@ -1,5 +1,6 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/clickUntilExhausted
 import { BrowserContext, Page } from "playwright";
-import { clickUntilExhausted, goToUrl } from "@intuned/browser";
+import { clickUntilExhausted } from "@intuned/browser";
 
 interface Params {
   // No params needed
@@ -10,21 +11,18 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  await goToUrl({ page, url: "https://careers.qualcomm.com/careers" });
+  await page.goto("https://sandbox.intuned.dev/load-more");
 
-  const buttonLocator = page.locator(
-    "xpath=//button[@class='btn btn-sm btn-secondary show-more-positions']"
-  );
+  const loadMoreButton = page.locator("main main button");  // Select the main button in the main content area.
 
-  // Click on the button to load more content 5 times.
-  // Check https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/clickUntilExhausted for more details.
+  // Click until button disappears or is disabled
   await clickUntilExhausted({
     page,
-    buttonLocator,
-    maxClicks: 5,
+    buttonLocator: loadMoreButton,
+    maxClicks: 20,
   });
 
-  // Now all content is loaded and visible
+  // Will keep clicking the button until the button disappears or is disabled or the max_clicks is reached.
   return "Success";
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/download-file.ts
+++ b/typescript-examples/browser-sdk-showcase/api/download-file.ts
@@ -1,3 +1,4 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/downloadFile
 import { BrowserContext, Page } from "playwright";
 import { downloadFile } from "@intuned/browser";
 
@@ -18,6 +19,7 @@ export default async function handler(
     trigger: "https://intuned-docs-public-images.s3.amazonaws.com/32UP83A_ENG_US.pdf",
     timeoutInMs: timeout,
   });
+  console.log("Result of downloading file from URL:");
   console.log(download.suggestedFilename());
 
   // Download from trigger
@@ -26,6 +28,7 @@ export default async function handler(
     page,
     trigger: page.locator("xpath=//tbody/tr[1]//*[name()='svg']"),
   });
+  console.log("Result of downloading file from trigger:");
   console.log(download.suggestedFilename());
 
   // Download from trigger with custom callable function
@@ -36,6 +39,7 @@ export default async function handler(
       await page.locator("xpath=//tbody/tr[1]//*[name()='svg']").click();
     },
   });
+  console.log("Result of downloading file from trigger with custom callable function:");
   console.log(download.suggestedFilename());
 
   return download.suggestedFilename();

--- a/typescript-examples/browser-sdk-showcase/api/extract-markdown.ts
+++ b/typescript-examples/browser-sdk-showcase/api/extract-markdown.ts
@@ -1,3 +1,4 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/extractMarkdown
 import { BrowserContext, Page } from "playwright";
 import { extractMarkdown } from "@intuned/browser";
 
@@ -15,6 +16,7 @@ export default async function handler(
   const headerLocator = page.locator("h1");
   const markdown = await extractMarkdown({ source: headerLocator }); // Extract markdown from the header locator.
   
+  console.log("Markdown content of the header:");
   console.log(markdown);
   return markdown;
 }

--- a/typescript-examples/browser-sdk-showcase/api/filter-empty-values.ts
+++ b/typescript-examples/browser-sdk-showcase/api/filter-empty-values.ts
@@ -1,3 +1,4 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/filterEmptyValues
 import { BrowserContext, Page } from "playwright";
 import { filterEmptyValues } from "@intuned/browser";
 
@@ -12,14 +13,17 @@ export default async function handler(
 ) {
   // Filter empty values from dictionary
   const result1 = filterEmptyValues({ data: { a: "", b: "hello", c: null } });
+  console.log("Result of filtering empty values from dictionary:");
   console.log(result1);
 
   // Filter empty values from list
   const result2 = filterEmptyValues({ data: [1, "", null, [2, ""]] });
+  console.log("Result of filtering empty values from list:");
   console.log(result2);
 
   // Filter nested structures
   const result3 = filterEmptyValues({ data: { users: [{ name: "" }, { name: "John" }] } });
+  console.log("Result of filtering nested structures:");
   console.log(result3);
 
   return { result1, result2, result3 };

--- a/typescript-examples/browser-sdk-showcase/api/go-to-url.ts
+++ b/typescript-examples/browser-sdk-showcase/api/go-to-url.ts
@@ -1,11 +1,10 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/goToUrl
 import { BrowserContext, Page } from "playwright";
 import { goToUrl } from "@intuned/browser";
 
 interface Params {
-  url?: string;
-  waitUntil?: "load" | "domcontentloaded" | "networkidle"
   timeout?: number;
-  waitForLoadingStateUsingAi?: boolean;
+  retries?: number;
 }
 
 export default async function handler(
@@ -13,22 +12,22 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  const url = params.url || "https://books.toscrape.com/";
-  const waitUntil = params.waitUntil || "load";
-  const timeout = params.timeout || 30000;
-  const waitForLoadingStateUsingAi = params.waitForLoadingStateUsingAi || false; // You must provide an API Key in the environment variables for this to work. Or use Intuned's Gateway.
-  // Navigate with custom options and enhanced reliability and automatic retries.
-  // Check https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/goToUrl for more details.
-  // waitForLoadingStateUsingAi uses isPageLoaded to determine if the page has finished loading.
+  const timeout = params.timeout || 15000;
+  const retries = params.retries || 3;
+
+  // Navigate to the URL with enhanced reliability and automatic retries.
+  // This will wait for the networkidle state more reliably than the default playwright behavior.
+  // When waitForLoadingStateUsingAi=true, the function uses isPageLoaded under the hood to determine
   await goToUrl({
     page,
-    url,
-    waitForLoadState: waitUntil,
-    timeoutInMs:timeout,
-    waitForLoadingStateUsingAi,
+    url: "https://books.toscrape.com",
+    timeoutInMs: timeout,
+    retries,
+    waitForLoadingStateUsingAi: true,
+    // Since we are not passing the apiKey, the function will use the Intuned AI Gateway.
   });
 
-  // Now the page is loaded and ready to use.
-  return `Successfully navigated to ${url}`;
+  // Start your automation here, the page is already loaded and ready to use.
+  return "Success";
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/process-date.ts
+++ b/typescript-examples/browser-sdk-showcase/api/process-date.ts
@@ -1,3 +1,4 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/processDate
 import { BrowserContext, Page } from "playwright";
 import { processDate } from "@intuned/browser";
 
@@ -12,22 +13,27 @@ export default async function handler(
 ) {
   // Basic date string
   const date1 = processDate({ date: "22/11/2024" });
+  console.log("Result of processing 22/11/2024:");
   console.log(date1); // 2024-11-22 00:00:00
 
   // Single-digit variant
   const date2 = processDate({ date: "8/16/2019" });
+  console.log("Result of processing 8/16/2019:");
   console.log(date2); // 2019-08-16 00:00:00
 
   // Date with time (time is ignored)
   const date3 = processDate({ date: "12/09/2024 9:00 AM" });
+  console.log("Result of processing 12/09/2024 9:00 AM:");
   console.log(date3); // 2024-12-09 00:00:00
 
   // With timezone
   const date4 = processDate({ date: "10/23/2024 12:06 PM CST" });
+  console.log("Result of processing 10/23/2024 12:06 PM CST:");
   console.log(date4); // 2024-10-23 00:00:00
 
   // Full month format
   const date5 = processDate({ date: "November 14, 2024" });
+  console.log("Result of processing November 14, 2024:");
   console.log(date5); // 2024-11-14 00:00:00
 
   return {

--- a/typescript-examples/browser-sdk-showcase/api/resolve-url.ts
+++ b/typescript-examples/browser-sdk-showcase/api/resolve-url.ts
@@ -1,3 +1,4 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/resolveUrl
 import { BrowserContext, Page } from "playwright";
 import { resolveUrl } from "@intuned/browser";
 
@@ -11,26 +12,29 @@ export default async function handler(
   context: BrowserContext
 ) {
   // Resolve a relative URL to an absolute URL
-  const absoluteUrl1 = await resolveUrl({
+  let absoluteUrl = await resolveUrl({
     url: "/api/users",
     baseUrl: "https://example.com",
   });
-  console.log(absoluteUrl1);
+  console.log("Result of resolving relative URL to absolute URL:");
+  console.log(absoluteUrl);
 
   // Resolve relative URL from the current page
   await page.goto("https://intunedhq.com");
-  const absoluteUrl2 = await resolveUrl({
+  absoluteUrl = await resolveUrl({
     url: "/blog/intuned-act-3",
     page,
   });
-  console.log(absoluteUrl2);
+  console.log("Result of resolving relative URL from the current page:");
+  console.log(absoluteUrl);
 
   // Resolve relative URL from an anchor tag
   await page.goto("https://intunedhq.com");
-  const absoluteUrl3 = await resolveUrl({
+  absoluteUrl = await resolveUrl({
     url: page.locator("a:has-text('Schedule a demo')"),
   });
-  console.log(absoluteUrl3);
+  console.log("Result of resolving relative URL from an anchor tag:");
+  console.log(absoluteUrl);
 
   return "Success";
 }

--- a/typescript-examples/browser-sdk-showcase/api/sanitize-html.ts
+++ b/typescript-examples/browser-sdk-showcase/api/sanitize-html.ts
@@ -1,7 +1,10 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/sanitizeHtml
 import { BrowserContext, Page } from "playwright";
 import { sanitizeHtml } from "@intuned/browser";
 
 interface Params {
+  removeStyles?: boolean;
+  maxAttributeLength?: number;
 }
 
 export default async function handler(
@@ -9,11 +12,14 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-    await page.goto("https://books.toscrape.com");
-    const firstRow = page.locator("ol.row").locator("li").first();
-    const html = await firstRow.innerHTML();
-    const sanitizedHtml = sanitizeHtml({ html });
-    console.log(sanitizedHtml);
-    return sanitizedHtml;
+  await page.goto("https://books.toscrape.com");
+  const removeStyles = params.removeStyles ?? true;
+  const maxAttributeLength = params.maxAttributeLength ?? 100;
+  const firstRow = page.locator("ol.row").locator("li").first();
+  const html = await firstRow.innerHTML();
+  const sanitizedHtml = sanitizeHtml({ html, removeStyles, maxAttributeLength });
+  console.log("Sanitized HTML:");
+  console.log(sanitizedHtml);
+  return sanitizedHtml;
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/scroll-to-load-content.ts
+++ b/typescript-examples/browser-sdk-showcase/api/scroll-to-load-content.ts
@@ -1,8 +1,10 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/scrollToLoadContent
 import { BrowserContext, Page } from "playwright";
 import { scrollToLoadContent, goToUrl } from "@intuned/browser";
 import { extendTimeout } from "@intuned/runtime";
 
 interface Params {
+  extendTimeoutOnScroll?: boolean;
   maxScrolls?: number;
 }
 
@@ -11,16 +13,21 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  const maxScrolls = params.maxScrolls || 5;
+  const extendTimeoutOnScroll = params.extendTimeoutOnScroll ?? false;
+  const maxScrolls = params.maxScrolls ?? 10;
 
-  await goToUrl({ page, url: "https://www.ycombinator.com/companies" });
+  await goToUrl({ page, url: "https://sandbox.intuned.dev/infinite-scroll" });
 
-  // Scroll to load all dynamic content
+  // Scroll through entire page content
+  // This will handle infinite scrolls by scrolling the page continuously, and when max_scrolls is reached, it will stop and the data items will be loaded.
+  // Read about extend_timeout: https://docs.intunedhq.com/docs/05-references/runtime-sdk-python/extend-timeout
   await scrollToLoadContent({
     source: page,
+    onScrollProgress: extendTimeoutOnScroll ? extendTimeout : () => {},
     maxScrolls,
   });
 
-  return "Content loaded successfully";
+  // Will keep scrolling until the page has loaded all content or the max_scrolls is reached.
+  return "Success";
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/upload-file-to-s3.ts
+++ b/typescript-examples/browser-sdk-showcase/api/upload-file-to-s3.ts
@@ -1,11 +1,9 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/uploadFileToS3
 import { BrowserContext, Page } from "playwright";
-import { uploadFileToS3, downloadFile, S3Configs } from "@intuned/browser";
+import { uploadFileToS3, downloadFile } from "@intuned/browser";
 
 interface Params {
-  bucket?: string;
-  region?: string;
-  accessKey?: string;
-  secretKey?: string;
+  // No params needed
 }
 
 export default async function handler(
@@ -13,39 +11,22 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  const bucket = params.bucket;
-  const region = params.region;
-  const accessKey = params.accessKey;
-  const secretKey = params.secretKey;
-
   // Download a file first
   const download = await downloadFile({
     page,
     trigger: "https://intuned-docs-public-images.s3.amazonaws.com/32UP83A_ENG_US.pdf",
   });
 
-  // Configure S3 configuration
-  // Priority: params → environment variables → Intuned's managed S3 bucket (default)
-  let s3Config: S3Configs | undefined = undefined;
-  if (bucket && region && accessKey && secretKey) {
-    s3Config = {
-      bucket: bucket,
-      region,
-      accessKeyId: accessKey,
-      secretAccessKey: secretKey,
-    };
-  }
-
   const uploadedFile = await uploadFileToS3({
     file: download,
-    configs: s3Config,
     fileNameOverride: "myfile.pdf",
     contentType: "application/pdf",
   });
 
   const signedUrl = await uploadedFile.getSignedUrl();
+  console.log("Signed URL:");
   console.log(signedUrl);
-  
+
   return signedUrl;
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/validate-data-using-schema.ts
+++ b/typescript-examples/browser-sdk-showcase/api/validate-data-using-schema.ts
@@ -1,3 +1,4 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/validateDataUsingSchema
 import { BrowserContext, Page } from "playwright";
 import { validateDataUsingSchema } from "@intuned/browser";
 
@@ -10,24 +11,31 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  const userData = {
-    name: "John Doe",
-    email: "john@example.com",
-    age: 30,
+  const uploadData = {
+    file: {
+      file_name: "documents/report.pdf",
+      bucket: "my-bucket",
+      region: "us-east-1",
+      key: "documents/report.pdf",
+      endpoint: null,
+      suggested_file_name: "Monthly Report.pdf",
+      file_type: "document",
+    },
+    name: "Test File Upload",
   };
 
-  const userSchema = {
+  const uploadSchema = {
     type: "object",
-    required: ["name", "email", "age"],
+    required: ["file", "name"],
     properties: {
-      name: { type: "string", minLength: 1 },
-      email: { type: "string" },
-      age: { type: "number", minimum: 0 },
+      file: { type: "attachment" },
+      name: { type: "string" },
     },
   };
 
-  validateDataUsingSchema({ data: userData, schema: userSchema });
-  
-  return "Data validated successfully";
+  validateDataUsingSchema({ data: uploadData, schema: uploadSchema });
+  // Validation passes with Attachment type, it also validates Pydantic Attachment type.
+  console.log("Validation passed");
+  return "Validation passed";
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/wait-for-dom-settled.ts
+++ b/typescript-examples/browser-sdk-showcase/api/wait-for-dom-settled.ts
@@ -1,30 +1,24 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/waitForDomSettled
 import { BrowserContext, Page } from "playwright";
-import { waitForDomSettled, goToUrl } from "@intuned/browser";
+import { waitForDomSettled } from "@intuned/browser";
 
 interface Params {
-  settleDuration?: number;
-  timeoutInMs?: number;
+  // No params needed
 }
+
+// Decorator without arguments (uses settleDurationMs=500, timeoutInMs=30000)
+const loadMoreContent = waitForDomSettled(async (page: Page) => {
+  await page.locator("main main button").click();
+});
 
 export default async function handler(
   params: Params,
   page: Page,
   context: BrowserContext
 ) {
-  const settleDuration = params.settleDuration || 500;
-  const timeoutInMs = params.timeoutInMs || 30000;
-
-  await goToUrl({ page, url: "https://careers.qualcomm.com/careers" });
-
-
-  await page.locator("xpath=//button[@class='btn btn-sm btn-secondary show-more-positions']").click();
-  await waitForDomSettled({
-    source: page,
-    settleDurationMs: settleDuration,
-    timeoutInMs,
-  })
-
+  await page.goto("https://sandbox.intuned.dev/load-more");
+  // Automatically waits for DOM to settle after clicking
+  await loadMoreContent(page);
   // DOM has settled, new content is loaded
-  return "Success";
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/wait-for-network-settled.ts
+++ b/typescript-examples/browser-sdk-showcase/api/wait-for-network-settled.ts
@@ -1,35 +1,24 @@
+// https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/waitForNetworkSettled
 import { BrowserContext, Page } from "playwright";
-import { withNetworkSettledWait, goToUrl } from "@intuned/browser";
+import { waitForNetworkSettled } from "@intuned/browser";
 
 interface Params {
-  timeout?: number;
-  maxInflightRequests?: number;
+  // No params needed
 }
+
+// Decorator without arguments (uses timeoutInMs=30000, maxInflightRequests=0)
+const clickLoadMore = waitForNetworkSettled(async (page: Page) => {
+  await page.locator("main main button").click();
+});
 
 export default async function handler(
   params: Params,
   page: Page,
   context: BrowserContext
 ) {
-  const timeout = params.timeout || 30000;
-  const maxInflightRequests = params.maxInflightRequests || 0;
-
-  await goToUrl({ page, url: "https://careers.qualcomm.com/careers" });
-
-  await withNetworkSettledWait(async (page: Page) => {
-    await page
-      .locator("xpath=//button[@class='btn btn-sm btn-secondary show-more-positions']")
-      .click();
-  },
-  {
-    page,
-    timeoutInMs: timeout,
-    maxInflightRequests,
-  });
-
+  await page.goto("https://sandbox.intuned.dev/load-more");
   // Automatically waits for network to settle after clicking
-
+  await clickLoadMore(page);
   // Network has settled, data is loaded
-  return "Success";
 }
 

--- a/typescript-examples/rpa-example/Intuned.jsonc
+++ b/typescript-examples/rpa-example/Intuned.jsonc
@@ -16,6 +16,18 @@
     "template": {
       "name": "rpa-example",
       "description": "RPA example for booking consultations without authentication"
+    },
+    "tags": ["rpa", "automation", "forms"],
+    "defaultRunPlaygroundInput": {
+      "apiName": "book-consultations",
+      "parameters": {
+        "name": "John Doe",
+        "email": "john.doe@example.com",
+        "phone": "1234567890",
+        "date": "2026-11-19",
+        "time": "10:00 AM",
+        "topic": "automation"
+      }
     }
   }
 }

--- a/typescript-examples/rpa-example/README.md
+++ b/typescript-examples/rpa-example/README.md
@@ -1,23 +1,33 @@
-# book-consultations Intuned project
+# RPA Example - Consultation Booking
 
-Booking automation to book a consultation with a consultant and list the consultations
+Booking automation example that demonstrates how to book consultations and retrieve consultation data without authentication.
 
+<!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
 Open this project in Intuned by clicking the button below.
 
 [![Run on Intuned](https://cdn1.intuned.io/button.svg)](https://app.intuned.io?repo=https://github.com/Intuned/cookbook/tree/main/typescript-examples/rpa-example)
+<!-- IDE-IGNORE-END -->
 
+## What This Example Does
+
+This example demonstrates basic RPA (Robotic Process Automation) workflows:
+
+1. **Book Consultations** - Automates filling out and submitting a consultation booking form with various topics (automation, API integration, data extraction, or other)
+2. **Get Consultations** - Retrieves consultation bookings for a specific email address
+
+<!-- IDE-IGNORE-START -->
 ## Getting Started
 
 To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
-
 
 ## Development
 
 > **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
 
-### Install dependencies
+### Install Dependencies
+
 ```bash
 # npm
 npm install
@@ -28,16 +38,23 @@ yarn
 
 > **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
 
-
 ### Run an API
 
 ```bash
-# Book a consultation
+# Book consultations with different topics
 # npm
 npm run intuned run api book-consultations .parameters/api/book-consultations/default.json
+npm run intuned run api book-consultations .parameters/api/book-consultations/automation-consultation.json
+npm run intuned run api book-consultations .parameters/api/book-consultations/api-integration-consultation.json
+npm run intuned run api book-consultations .parameters/api/book-consultations/data-extraction-consultation.json
+npm run intuned run api book-consultations .parameters/api/book-consultations/other-topic-consultation.json
 
 # yarn
 yarn intuned run api book-consultations .parameters/api/book-consultations/default.json
+yarn intuned run api book-consultations .parameters/api/book-consultations/automation-consultation.json
+yarn intuned run api book-consultations .parameters/api/book-consultations/api-integration-consultation.json
+yarn intuned run api book-consultations .parameters/api/book-consultations/data-extraction-consultation.json
+yarn intuned run api book-consultations .parameters/api/book-consultations/other-topic-consultation.json
 
 # Get consultations by email
 # npm
@@ -47,107 +64,48 @@ npm run intuned run api get-consultations-by-email .parameters/api/get-consultat
 yarn intuned run api get-consultations-by-email .parameters/api/get-consultations-by-email/default.json
 ```
 
-### Deploy project
+### Deploy to Intuned
+
 ```bash
 # npm
 npm run intuned deploy
 
 # yarn
 yarn intuned deploy
-
 ```
+<!-- IDE-IGNORE-END -->
 
 
+## `@intuned/browser`: Intuned Browser SDK
 
-
-
-
-
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).
 
 ## Project Structure
-The project structure is as follows:
+
 ```
 /
-├── apis/                     # Your API endpoints 
-│   └── ...   
-├── auth-sessions/            # Auth session related APIs
-│   ├── check.ts           # API to check if the auth session is still valid
-│   └── create.ts          # API to create/recreate the auth session programmatically
-├── auth-sessions-instances/  # Auth session instances created and used by the CLI
-│   └── ...
-└── Intuned.jsonc              # Intuned project configuration file
+├── api/
+│   ├── book-consultations.ts              # Book a consultation
+│   └── get-consultations-by-email.ts      # Get consultations for an email
+├── .parameters/
+│   └── api/
+│       ├── book-consultations/
+│       │   ├── default.json                        # Default booking (other topic)
+│       │   ├── automation-consultation.json        # Automation topic
+│       │   ├── api-integration-consultation.json   # API integration topic
+│       │   ├── data-extraction-consultation.json   # Data extraction topic
+│       │   └── other-topic-consultation.json       # Other topic
+│       └── get-consultations-by-email/
+│           └── default.json                        # Get consultations query
+├── utils/
+│   └── typesAndSchemas.ts              # Type definitions and schemas
+├── Intuned.jsonc                       # Intuned project configuration
+├── package.json                        # Dependencies
+└── tsconfig.json                       # TypeScript configuration
 ```
 
+## Learn More
 
-## `Intuned.jsonc` Reference
-```jsonc
-{
-  // Your Intuned workspace ID. 
-  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
-  "workspaceId": "your_workspace_id",
-
-  // The name of your Intuned project. 
-  // Optional - If not provided here, it must be supplied via the command line when deploying.
-  "projectName": "your_project_name",
-
-  // Replication settings
-  "replication": {
-    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
-    // A number of machines equal to this will be allocated to handle API requests.
-    // Not applicable if api access is disabled.
-    "maxConcurrentRequests": 1,
-
-    // The machine size to use for this project. This is applicable for both API requests and jobs.
-    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
-    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
-    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
-    "size": "standard"
-  }
-
-  // Auth session settings
-  "authSessions": {
-    // Whether auth sessions are enabled for this project.
-    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
-    "enabled": true,
-
-    // Whether to save Playwright traces for auth session runs.
-    "saveTraces": false,
-
-    // The type of auth session to use.
-    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
-    // "MANUAL" type uses a recorder to manually create the auth session.
-    "type": "API",
-    
-
-    // Recorder start URL for the recorder to navigate to when creating the auth session.
-    // Required if "type" is "MANUAL". Not used if "type" is "API".
-    "startUrl": "https://example.com/login",
-
-    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
-    // Required if "type" is "MANUAL". Not used if "type" is "API".
-    "finishUrl": "https://example.com/dashboard",
-
-    // Recorder browser mode
-    // "fullscreen": Launches the browser in fullscreen mode.
-    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
-    // Only applicable for "MANUAL" type.
-    "browserMode": "fullscreen"
-  }
-  
-  // API access settings
-  "apiAccess": {
-    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
-    // This is required for projects that use auth sessions.
-    "enabled": true
-  },
-
-  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
-  "headful": false,
-
-  // The region where your Intuned project is hosted.
-  // For a list of available regions, contact support or refer to the documentation.
-  // Optional - Default: "us"
-  "region": "us"
-}
-```
-  
+- **Intuned Concepts**: https://docs.intunedhq.com/docs/00-getting-started/introduction
+- **Intuned Browser SDK**: https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview
+- **CLI Documentation**: https://docs.intunedhq.com/docs/05-references/cli

--- a/typescript-examples/stagehand/Intuned.jsonc
+++ b/typescript-examples/stagehand/Intuned.jsonc
@@ -15,13 +15,14 @@
   "metadata": {
     "template": {
       "name": "stagehand",
-      "description": "AI-powered browser automation using Stagehand library",
-      "tags": [
-        "Stagehand",
-        "AI",
-        "intuned-runtime-sdk",
-        "intuned-runtime-sdk-setup-context-hook"
-      ]
+      "description": "AI-powered browser automation using Stagehand library"
+    },
+    "tags": ["ai", "stagehand", "automation"],
+    "defaultRunPlaygroundInput": {
+      "apiName": "get-books",
+      "parameters": {
+        "category": "Travel"
+      }
     }
   }
 }


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

