### PR TITLE
fix auth with otp template

### DIFF
--- a/python-examples/auth-with-secret-otp/Intuned.jsonc
+++ b/python-examples/auth-with-secret-otp/Intuned.jsonc
@@ -15,9 +15,15 @@
       "name": "auth-with-secret-otp",
       "description": "Authentication example using secret-based OTP verification"
     },
+    "tags": ["auth", "OTP", "2FA", "authentication"],
+    "defaultRunPlaygroundInput": {
+      "apiName": "list-contracts",
+      "parameters": {}
+    },
     "testAuthSessionInput": {
       "username": "demo@email.com",
-      "password": "password"
+      "password": "DemoUser2024!",
+      "secret": "JBSWY3DPEHPK3PXP"
     }
   }
 }

--- a/python-examples/auth-with-secret-otp/README.md
+++ b/python-examples/auth-with-secret-otp/README.md
@@ -1,7 +1,8 @@
-# auth-with-secret-otp Intuned project
+# Auth with Secret OTP
 
-Authentication automation with multi-step OTP verification
+Authentication automation with multi-step OTP verification using a secret key.
 
+<!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
 Open this project in Intuned by clicking the button below.
@@ -10,12 +11,15 @@ Open this project in Intuned by clicking the button below.
 
 ## Getting Started
 
-To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+To get started developing browser automation projects with Intuned, check out the 
+- Intuned docs [here](https://docs.intunedhq.com/docs/00-getting-started/introduction)
+- CLI docs [here](https://docs.intunedhq.com/docs/05-references/cli)
+- Intuned.jsonc docs [here](https://docs.intunedhq.com/docs/05-references/intuned-json#intuned-json)
 
 
 ## Development
 
-> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+> **_NOTE:_** All commands support `--help` flag to get more information about the command and its arguments and options.
 
 ### Install dependencies
 ```bash
@@ -25,8 +29,36 @@ uv sync
 After installing dependencies, `intuned` command should be available in your environment.
 
 ### Run an API
+
 ```bash
-uv run intuned run api list-contracts .parameters/api/list-contracts/default.json --auth-session <auth-session-id>
+uv run intuned run api list-contracts .parameters/api/list-contracts/default.json --auth-session test-auth-session
+```
+
+### Save project
+
+```bash
+uv run intuned run save
+```
+
+Reference for saving project [here](https://docs.intunedhq.com/docs/02-features/local-development-cli#use-runtime-sdk-and-browser-sdk-helpers)
+
+## Auth Sessions
+
+This project uses Intuned Auth Sessions. To learn more, check out the [Authenticated Browser Automations: Conceptual Guide](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/authenticated-browser-automations-conceptual-guide).
+
+### Create a new auth session
+```bash
+uv run intuned run authsession create .parameters/auth-sessions/create/default.json
+```
+
+### Update an existing auth session
+```bash
+uv run intuned run authsession update test-auth-session
+```
+
+### Validate an auth session
+```bash
+uv run intuned run authsession validate test-auth-session
 ```
 
 ### Deploy project
@@ -34,99 +66,42 @@ uv run intuned run api list-contracts .parameters/api/list-contracts/default.jso
 uv run intuned deploy
 ```
 
-
-
-
 ### `intuned-browser`: Intuned Browser SDK
 
-This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).
 
-
-
+<!-- IDE-IGNORE-END -->
 
 ## Project Structure
-The project structure is as follows:
+
 ```
 /
-├── api/                      # Your API endpoints
-│   └── ...
-├── auth-sessions/            # Auth session related APIs
-│   ├── check.py           # API to check if the auth session is still valid
-│   └── create.py          # API to create/recreate the auth session programmatically
-├── auth-sessions-instances/  # Auth session instances created and used by the CLI
-│   └── ...
-└── Intuned.jsonc              # Intuned project configuration file
+├── api/                          # API endpoints
+│   └── list-contracts.py         # List all contracts
+├── auth-sessions/                # Auth session related APIs
+│   ├── check.py                  # API to check if the auth session is still valid
+│   └── create.py                 # API to create/recreate the auth session programmatically
+├── auth-sessions-instances/      # Auth session instances created and used by the CLI
+│   └── test-auth-session/        # Example test auth session
+│       ├── auth-session.json     # Browser state (cookies, localStorage)
+│       └── metadata.json         # Auth session metadata
+├── .parameters/                  # Test parameters for APIs
+│   ├── api/                      # API parameters folder
+│   │   └── list-contracts/
+│   │       └── default.json
+│   └── auth-sessions/            # Auth session parameters
+│       ├── check/
+│       │   └── default.json
+│       └── create/
+│           └── default.json
+├── utils/                        # Utility modules
+│   └── types_and_schemas.py     # Type definitions and schemas
+├── Intuned.jsonc                 # Intuned project configuration file
+└── pyproject.toml                # Python project dependencies
 ```
 
+## Learn More
 
-## `Intuned.jsonc` Reference
-```jsonc
-{
-  // Your Intuned workspace ID.
-  // Optional - If not provided here, it must be supplied via the `--workspace-id` flag during deployment.
-  "workspaceId": "your_workspace_id",
-
-  // The name of your Intuned project.
-  // Optional - If not provided here, it must be supplied via the command line when deploying.
-  "projectName": "your_project_name",
-
-  // Replication settings
-  "replication": {
-    // The maximum number of concurrent executions allowed via Intuned API. This does not affect jobs.
-    // A number of machines equal to this will be allocated to handle API requests.
-    // Not applicable if api access is disabled.
-    "maxConcurrentRequests": 1,
-
-    // The machine size to use for this project. This is applicable for both API requests and jobs.
-    // "standard": Standard machine size (6 shared vCPUs, 2GB RAM)
-    // "large": Large machine size (8 shared vCPUs, 4GB RAM)
-    // "xlarge": Extra large machine size (1 performance vCPU, 8GB RAM)
-    "size": "standard"
-  }
-
-  // Auth session settings
-  "authSessions": {
-    // Whether auth sessions are enabled for this project.
-    // If enabled, "auth-sessions/check.ts" API must be implemented to validate the auth session.
-    "enabled": true,
-
-    // Whether to save Playwright traces for auth session runs.
-    "saveTraces": false,
-
-    // The type of auth session to use.
-    // "API" type requires implementing "auth-sessions/create.ts" API to create/recreate the auth session programmatically.
-    // "MANUAL" type uses a recorder to manually create the auth session.
-    "type": "API",
-
-
-    // Recorder start URL for the recorder to navigate to when creating the auth session.
-    // Required if "type" is "MANUAL". Not used if "type" is "API".
-    "startUrl": "https://example.com/login",
-
-    // Recorder finish URL for the recorder. Once this URL is reached, the recorder stops and saves the auth session.
-    // Required if "type" is "MANUAL". Not used if "type" is "API".
-    "finishUrl": "https://example.com/dashboard",
-
-    // Recorder browser mode
-    // "fullscreen": Launches the browser in fullscreen mode.
-    // "kiosk": Launches the browser in kiosk mode (no address bar, no navigation controls).
-    // Only applicable for "MANUAL" type.
-    "browserMode": "fullscreen"
-  }
-
-  // API access settings
-  "apiAccess": {
-    // Whether to enable consumption through Intuned API. If this is false, the project can only be consumed through jobs.
-    // This is required for projects that use auth sessions.
-    "enabled": true
-  },
-
-  // Whether to run the deployed API in a headful browser. Running in headful can help with some anti-bot detections. However, it requires more resources and may work slower or crash if the machine size is "standard".
-  "headful": false,
-
-  // The region where your Intuned project is hosted.
-  // For a list of available regions, contact support or refer to the documentation.
-  // Optional - Default: "us"
-  "region": "us"
-}
-```
+- [Auth Sessions Documentation](https://docs.intunedhq.com/docs/02-features/auth-sessions)
+- [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview)
+- [OTP Authentication Guide](https://docs.intunedhq.com/docs/01-learn/deep-dives/intuned-indepth)

--- a/python-examples/auth-with-secret-otp/api/list-contracts.py
+++ b/python-examples/auth-with-secret-otp/api/list-contracts.py
@@ -1,8 +1,12 @@
-from typing import Optional, List
+from typing import TypedDict, List
 from playwright.async_api import Page
 from intuned_browser import go_to_url
 
 from utils.types_and_schemas import Contract
+
+
+class Params(TypedDict):
+    pass
 
 
 async def extract_contracts_from_table(page: Page) -> List[Contract]:
@@ -71,8 +75,8 @@ async def extract_contracts_from_table(page: Page) -> List[Contract]:
     return contracts
 
 
-async def handler(
-    page: Page, params: Optional[dict] = None, **_kwargs
+async def automation(
+    page: Page, params: Params | None = None, **_kwargs
 ) -> List[Contract]:
     # Navigate to the contracts list authentication page
     await go_to_url(

--- a/typescript-examples/rpa-auth-example/README.md
+++ b/typescript-examples/rpa-auth-example/README.md
@@ -74,19 +74,19 @@ yarn intuned run authsession create .parameters/auth-sessions/create/default.jso
 ### Update an existing auth session
 ```bash
 # npm
-npm run intuned run authsession update <auth-session-id>
+npm run intuned run authsession update test-auth-session
 
 # yarn
-yarn intuned run authsession update <auth-session-id>
+yarn intuned run authsession update test-auth-session
 ```
 
 ### Validate an auth session
 ```bash
 # npm
-npm run intuned run authsession validate <auth-session-id>
+npm run intuned run authsession validate test-auth-session
 
 # yarn
-yarn intuned run authsession validate <auth-session-id>
+yarn intuned run authsession validate test-auth-session
 ```
 
 


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

