### PR TITLE
CDP and Setup hooks templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [e-commerece-category](./typescript-examples/e-commerece-category/) | E-commerce category and product scraper |
 | [hybrid-automation](./typescript-examples/hybrid-automation/) | Hybrid automation combining Intuned Browser SDK with AI-powered tools like Stagehand and extractStructuredData |
 | [computer-use](./typescript-examples/computer-use/) | AI-powered browser automation with Anthropic, OpenAI, and Gemini |
+| [cdp-connection](./typescript-examples/cdp-connection/) | Basic example demonstrating Chrome DevTools Protocol (CDP) connection |
+| [setup-hooks](./typescript-examples/setup-hooks/) | Demonstrates setup hooks for preparing data before API execution |
 | [jsdom-example](./typescript-examples/jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 | [network-interception](./typescript-examples/network-interception/) | Network interception for CSRF token capture and paginated API data |
 | [stagehand](./typescript-examples/stagehand/) | AI-powered browser automation with Stagehand |
@@ -45,6 +47,8 @@ A collection of examples for building browser automations with [Intuned](https:/
 | [e-commerece-category](./python-examples/e-commerece-category/) | E-commerce category and product scraper |
 | [hyprid-automation](./python-examples/hyprid-automation/) | Hybrid automation combining Intuned Browser SDK with AI-powered tools like Stagehand and extract_structured_data |
 | [computer-use](./python-examples/computer-use/) | AI-powered browser automation with Anthropic, OpenAI, Gemini, and Browser Use |
+| [cdp-connection](./python-examples/cdp-connection/) | Basic example demonstrating Chrome DevTools Protocol (CDP) connection |
+| [setup-hooks](./python-examples/setup-hooks/) | Demonstrates setup hooks for preparing data before API execution |
 | [bs4-example](./python-examples/bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |
 | [scrapy-example](./python-examples/scrapy-example/) | Web scraping with Scrapy framework (HTTP requests and Playwright integration) |
 | [network-interception](./python-examples/network-interception/) | Network interception for CSRF token capture and paginated API data |

--- a/python-examples/README.md
+++ b/python-examples/README.md
@@ -16,6 +16,8 @@ Intuned sample projects in Python.
 | [e-commerece-category](./e-commerece-category/) | E-commerce category and product scraper |
 | [hyprid-automation](./hyprid-automation/) | Hybrid automation combining Intuned Browser SDK with AI-powered tools like Stagehand and extract_structured_data |
 | [computer-use](./computer-use/) | AI-powered browser automation with Anthropic, OpenAI, and Gemini |
+| [cdp-connection](./cdp-connection/) | Basic example demonstrating Chrome DevTools Protocol (CDP) connection |
+| [setup-hooks](./setup-hooks/) | Demonstrates setup hooks for preparing data before API execution |
 | [bs4-example](./bs4-example/) | Web scraping with BeautifulSoup for HTML parsing |
 | [scrapy-example](./scrapy-example/) | Web scraping with Scrapy framework (HTTP requests and Playwright integration) |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving & stealth mode usage examples |

--- a/python-examples/cdp-connection/.gitignore
+++ b/python-examples/cdp-connection/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/python-examples/cdp-connection/.parameters/api/connect-to-cdp/default.json
+++ b/python-examples/cdp-connection/.parameters/api/connect-to-cdp/default.json
@@ -1,0 +1,3 @@
+{
+  "url": "https://books.toscrape.com/index.html"
+}

--- a/python-examples/cdp-connection/Intuned.jsonc
+++ b/python-examples/cdp-connection/Intuned.jsonc
@@ -1,0 +1,20 @@
+// For more information, see our Intuned settings reference
+// https://docs.intunedhq.com/docs/05-references/intuned-json
+{
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "template": {
+      "name": "CDP Connection",
+      "description": "Basic example demonstrating how to connect to a browser using Chrome DevTools Protocol (CDP)"
+    }
+  }
+}

--- a/python-examples/cdp-connection/Intuned.jsonc
+++ b/python-examples/cdp-connection/Intuned.jsonc
@@ -13,7 +13,7 @@
   },
   "metadata": {
     "template": {
-      "name": "CDP Connection",
+      "name": "cdp-connection",
       "description": "Basic example demonstrating how to connect to a browser using Chrome DevTools Protocol (CDP)"
     }
   }

--- a/python-examples/cdp-connection/README.md
+++ b/python-examples/cdp-connection/README.md
@@ -13,37 +13,25 @@ To get started developing browser automation projects with Intuned, check out ou
 
 ### Install dependencies
 ```bash
-# npm
-npm install
-
-# yarn
-yarn
+uv sync
 ```
 
-> **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
+After installing dependencies, `intuned` command should be available in your environment.
 
 ### Run an API
 ```bash
-# npm
-npm run intuned run api connect-to-cdp .parameters/api/connect-to-cdp/default.json
-
-# yarn
-yarn intuned run api connect-to-cdp .parameters/api/connect-to-cdp/default.json
+uv run intuned run api connect-to-cdp .parameters/api/connect-to-cdp/default.json
 ```
 
 ### Deploy project
 ```bash
-# npm
-npm run intuned deploy
-
-# yarn
-yarn intuned deploy
+uv run intuned deploy
 ```
 
 
 
 
-### `@intuned/browser`: Intuned Browser SDK
+### `intuned-browser`: Intuned Browser SDK
 
 This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
 
@@ -55,11 +43,11 @@ The project structure is as follows:
 ```
 /
 ├── api/                      # Your API endpoints
-│   └── connect-to-cdp.ts     # CDP connection example
+│   └── connect-to-cdp.py     # CDP connection example
 ├── hooks/                    # Setup hooks that run before API execution
-│   └── setupContext.ts       # Captures CDP URL from Intuned runtime
+│   └── setup_context.py      # Captures CDP URL from Intuned runtime
 ├── utils/                    # Utility functions and schemas
-│   └── typesAndSchemas.ts    # Zod schemas and TypeScript types
+│   └── types_and_schemas.py  # Pydantic models and type definitions
 ├── .parameters/              # Parameter files for testing APIs
 │   └── api/                  # API parameters folder
 │       └── connect-to-cdp/   # Parameters for CDP connection API

--- a/python-examples/cdp-connection/api/connect-to-cdp.py
+++ b/python-examples/cdp-connection/api/connect-to-cdp.py
@@ -1,0 +1,141 @@
+import httpx
+import platform
+from playwright.async_api import Page
+from intuned_runtime import attempt_store
+from pydantic import ValidationError
+from intuned_browser import go_to_url
+from utils.types_and_schemas import (
+    ConnectToCdpParams,
+    BrowserInfo,
+    PageInfo,
+    WebDriverInfo,
+    CDPConnectionResult,
+)
+
+
+async def get_browser_info(cdp_url: str) -> BrowserInfo:
+    """
+    Fetches browser information from the CDP endpoint
+    """
+    version_url = (
+        f"{cdp_url}json/version" if cdp_url.endswith("/") else f"{cdp_url}/json/version"
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(version_url)
+        data = response.json()
+
+    return BrowserInfo(
+        browser_version=data["Browser"],
+        protocol_version=data["Protocol-Version"],
+        user_agent=data["User-Agent"],
+        web_socket_debugger_url=data["webSocketDebuggerUrl"],
+    )
+
+
+async def automation(page: Page, params: dict | None = None, **_kwargs) -> dict:
+    """
+    CDP Connection Example
+
+    This function demonstrates how to:
+    1. Get CDP URL from Intuned runtime
+    2. Fetch browser information via CDP
+    3. Use Playwright with existing CDP connection
+    4. Navigate and extract page information
+    """
+    print("=== CDP Connection Example ===\n")
+
+    # Validate parameters using Pydantic schema
+    if not params:
+        raise ValueError("Missing required parameters")
+
+    try:
+        validated_params = ConnectToCdpParams(**params)
+    except ValidationError as e:
+        errors = ", ".join([f"{err['loc'][0]}: {err['msg']}" for err in e.errors()])
+        raise ValueError(f"Parameter validation failed: {errors}")
+
+    url = validated_params.url
+
+    # Get CDP URL from Intuned's runtime (provided via setup_context hook)
+    cdp_url = attempt_store.get("cdp_url")
+    if not cdp_url:
+        raise ValueError("CDP URL not found in attempt_store")
+
+    print(f"✓ CDP URL: {cdp_url}")
+
+    # Step 1: Fetch browser information via CDP
+    browser_info = await get_browser_info(cdp_url)
+    print("\n✓ Browser Information:")
+    print(f"  - Browser Version: {browser_info.browser_version}")
+    print(f"  - Protocol Version: {browser_info.protocol_version}")
+    print(f"  - User Agent: {browser_info.user_agent}")
+    print(f"  - WebSocket URL: {browser_info.web_socket_debugger_url}")
+
+    # Step 2: Get WebDriver capabilities using CDP
+    # Create a CDP session to execute CDP commands
+    cdp_session = await page.context.new_cdp_session(page)
+
+    print("\n✓ WebDriver Information:")
+    print("  WebDriver is a W3C standard protocol for browser automation.")
+    print("  CDP (Chrome DevTools Protocol) is Chrome-specific and more powerful.")
+
+    # Get browser capabilities through CDP
+    browser_capabilities = await cdp_session.send("Browser.getVersion")
+
+    web_driver_info = WebDriverInfo(
+        capabilities={
+            "browserName": "chromium",
+            "browserVersion": browser_capabilities["product"],
+            "platformName": platform.system(),
+            "cdpEnabled": True,
+            "webDriverBiDiSupported": False,  # Playwright uses CDP, not WebDriver BiDi
+        },
+        session_id=None,  # CDP doesn't use WebDriver session IDs
+    )
+
+    print(f"  - Browser Name: {web_driver_info.capabilities['browserName']}")
+    print(f"  - Browser Version: {web_driver_info.capabilities['browserVersion']}")
+    print(f"  - Platform: {web_driver_info.capabilities['platformName']}")
+    print(f"  - CDP Enabled: {web_driver_info.capabilities['cdpEnabled']}")
+    print(
+        f"  - WebDriver BiDi: {web_driver_info.capabilities['webDriverBiDiSupported']}"
+    )
+
+    # Close CDP session
+    await cdp_session.detach()
+
+    # Step 3: Use the Playwright page (already connected via CDP)
+    # The page object is already connected to the browser via CDP
+    print("\n✓ Playwright page is ready and connected via CDP")
+
+    # Step 4: Navigate to a URL
+    print(f"\n✓ Navigating to: {url}")
+    await go_to_url(page, url)
+
+    # Step 5: Get page information
+    title = await page.title()
+    current_url = page.url
+
+    page_info = PageInfo(
+        title=title,
+        url=current_url,
+    )
+
+    print("\n✓ Page Information:")
+    print(f"  - Title: {page_info.title}")
+    print(f"  - URL: {page_info.url}")
+    print(f"  - Viewport: {page_info.viewport.width}x{page_info.viewport.height}")
+
+    print("\n✓ CDP connection successful!\n")
+
+    result = CDPConnectionResult(
+        message="Successfully connected to browser via CDP and retrieved information",
+        cdp_url=cdp_url,
+        browser_info=browser_info,
+        page_info=page_info,
+        web_driver_info=web_driver_info,
+    )
+
+    # Use mode='json' to serialize all Pydantic types to JSON-compatible primitives
+    return result.model_dump(mode="json")

--- a/python-examples/cdp-connection/hooks/setup_context.py
+++ b/python-examples/cdp-connection/hooks/setup_context.py
@@ -1,0 +1,9 @@
+from intuned_runtime import attempt_store
+
+
+async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
+    """
+    Setup hook that runs before API execution.
+    Captures the CDP URL from Intuned's runtime and stores it in attempt_store.
+    """
+    attempt_store.set("cdp_url", cdp_url)

--- a/python-examples/cdp-connection/pyproject.toml
+++ b/python-examples/cdp-connection/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cdp-connection"
+version = "0.0.1"
+description = "Basic example demonstrating CDP connection with Intuned"
+authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
+requires-python = ">=3.12,<3.13"
+readme = "README.md"
+keywords = [
+    "Python",
+]
+dependencies = [
+    "playwright==1.56",
+    "intuned-runtime==1.3.14",
+    "intuned-browser==0.1.11",
+    "httpx==0.28.1",
+    "pydantic>=2.0.0",
+]
+
+[tool.uv]
+package = false

--- a/python-examples/cdp-connection/utils/types_and_schemas.py
+++ b/python-examples/cdp-connection/utils/types_and_schemas.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+
+
+class ConnectToCdpParams(BaseModel):
+    """Parameters for connect-to-cdp API"""
+
+    url: str
+
+
+class BrowserInfo(BaseModel):
+    """Browser information from CDP endpoint"""
+
+    browser_version: str
+    protocol_version: str
+    user_agent: str
+    web_socket_debugger_url: str  # WebSocket URL as string (ws:// or wss://)
+
+
+class PageInfo(BaseModel):
+    """Page information"""
+
+    title: str
+    url: str  # Page URL as string
+
+
+class WebDriverInfo(BaseModel):
+    """WebDriver capabilities and session info"""
+
+    capabilities: dict
+    session_id: str | None = None
+
+
+class CDPConnectionResult(BaseModel):
+    """Result returned from CDP connection API"""
+
+    message: str
+    cdp_url: str  # CDP URL can be HTTP or WS, use string for flexibility
+    browser_info: BrowserInfo
+    page_info: PageInfo
+    web_driver_info: WebDriverInfo

--- a/python-examples/setup-hooks/.gitignore
+++ b/python-examples/setup-hooks/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/python-examples/setup-hooks/.parameters/api/demo-hook/default.json
+++ b/python-examples/setup-hooks/.parameters/api/demo-hook/default.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello from Setup Hooks!"
+}

--- a/python-examples/setup-hooks/Intuned.jsonc
+++ b/python-examples/setup-hooks/Intuned.jsonc
@@ -13,8 +13,8 @@
   },
   "metadata": {
     "template": {
-      "name": "CDP Connection",
-      "description": "Basic example demonstrating how to connect to a browser using Chrome DevTools Protocol (CDP)"
+      "name": "Setup Hooks",
+      "description": "Demonstrates how to use setup hooks to prepare data and configuration before API execution"
     }
   }
 }

--- a/python-examples/setup-hooks/Intuned.jsonc
+++ b/python-examples/setup-hooks/Intuned.jsonc
@@ -13,7 +13,7 @@
   },
   "metadata": {
     "template": {
-      "name": "Setup Hooks",
+      "name": "setup-hooks",
       "description": "Demonstrates how to use setup hooks to prepare data and configuration before API execution"
     }
   }

--- a/python-examples/setup-hooks/README.md
+++ b/python-examples/setup-hooks/README.md
@@ -1,0 +1,56 @@
+# setup-hooks Intuned project
+
+Example demonstrating how to use setup hooks in Intuned to prepare data and configuration before your API executes
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+uv sync
+```
+
+After installing dependencies, `intuned` command should be available in your environment.
+
+### Run an API
+```bash
+uv run intuned run api demo-hook .parameters/api/demo-hook/default.json
+```
+
+### Deploy project
+```bash
+uv run intuned deploy
+```
+
+
+
+
+### `intuned-browser`: Intuned Browser SDK
+
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+
+
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── api/                      # Your API endpoints
+│   └── demo-hook.py          # Demo API showing hook data usage
+├── hooks/                    # Setup hooks executed before API runs
+│   └── setup_context.py      # Main setup hook
+├── utils/                    # Utility functions and schemas
+│   └── types_and_schemas.py  # Pydantic models and type definitions
+├── .parameters/              # Parameter files for testing APIs
+│   └── api/                  # API parameters folder
+│       └── demo-hook/        # Parameters for demo API
+│           └── default.json  # Default parameters
+└── Intuned.jsonc             # Intuned project configuration file
+```

--- a/python-examples/setup-hooks/api/demo-hook.py
+++ b/python-examples/setup-hooks/api/demo-hook.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from playwright.async_api import Page
+from intuned_runtime import attempt_store
+from pydantic import ValidationError
+from intuned_browser import go_to_url
+from utils.types_and_schemas import (
+    DemoHookParams,
+    DataFromHook,
+    HookDemoResult,
+)
+
+
+async def automation(page: Page, params: dict | None = None, **_kwargs) -> dict:
+    """
+    Setup Hooks Demo API
+
+    This function demonstrates how to:
+    1. Retrieve data stored by the setup hook
+    2. Use the stored CDP URL for browser operations
+    3. Calculate execution time using hook timestamps
+    """
+    print("=== Setup Hooks Demo API ===\n")
+
+    # Validate parameters using Pydantic schema
+    if not params:
+        params = {}
+
+    try:
+        validated_params = DemoHookParams(**params)
+    except ValidationError as e:
+        errors = ", ".join([f"{err['loc'][0]}: {err['msg']}" for err in e.errors()])
+        raise ValueError(f"Parameter validation failed: {errors}")
+
+    message = validated_params.message or "Hello from Setup Hooks!"
+
+    # Step 1: Retrieve data that was stored by the setup hook
+    print("📦 Retrieving data from setup hook...\n")
+
+    cdp_url = attempt_store.get("cdp_url")
+    api_name = attempt_store.get("api_name")
+    api_parameters = attempt_store.get("api_parameters")
+    execution_start_time = attempt_store.get("execution_start_time")
+    config = attempt_store.get("config")
+    user_agent = attempt_store.get("user_agent")
+
+    print("✓ Data retrieved from attempt_store:")
+    print(f"  - CDP URL: {cdp_url}")
+    print(f"  - API Name: {api_name}")
+    print(f"  - Execution Start: {execution_start_time}")
+    print(f"  - User Agent: {user_agent}")
+    print(f"  - Config: {config}")
+
+    # Step 2: Use the page (connected via CDP thanks to the hook)
+    print("\n🌐 Navigating to example.com...")
+    await go_to_url(page, url="https://example.com")
+    page_title = await page.title()
+    print(f"✓ Page Title: {page_title}")
+
+    # Step 3: Calculate execution time
+    end_time = datetime.now()
+    start_time = datetime.fromisoformat(execution_start_time)
+    execution_ms = int((end_time - start_time).total_seconds() * 1000)
+    execution_time = f"{execution_ms}ms"
+    print(f"\n⏱️  Total Execution Time: {execution_time}")
+
+    print("\n✅ Setup Hooks Demo Complete!\n")
+
+    result = HookDemoResult(
+        message=message,
+        data_from_hook=DataFromHook(
+            cdp_url=cdp_url,
+            api_name=api_name,
+            api_parameters=api_parameters,
+            execution_start_time=execution_start_time,
+            config=config,
+            user_agent=user_agent,
+        ),
+        execution_time=execution_time,
+        page_title=page_title,
+    )
+
+    # Use mode='json' to serialize all Pydantic types to JSON-compatible primitives
+    return result.model_dump(mode="json")

--- a/python-examples/setup-hooks/hooks/setup_context.py
+++ b/python-examples/setup-hooks/hooks/setup_context.py
@@ -1,0 +1,49 @@
+import os
+from datetime import datetime
+from intuned_runtime import attempt_store
+
+
+async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
+    """
+    Setup Hook - Runs before your API executes
+
+    Purpose: Prepare data, configuration, or state that your API will need
+
+    This hook demonstrates:
+    1. Storing the CDP URL for browser connection
+    2. Storing API metadata (name and parameters)
+    3. Adding custom configuration or computed values
+    4. Setting up timestamps for tracking
+    """
+    print("🔧 Setup Hook: Preparing environment...")
+
+    # 1. Store CDP URL for browser operations
+    attempt_store.set("cdp_url", cdp_url)
+    print(f"  ✓ CDP URL stored: {cdp_url}")
+
+    # 2. Store API metadata for reference
+    attempt_store.set("api_name", api_name)
+    attempt_store.set("api_parameters", api_parameters)
+    print(f"  ✓ API Name: {api_name}")
+    print(f"  ✓ Parameters: {api_parameters}")
+
+    # 3. Add execution timestamp
+    start_time = datetime.now().isoformat()
+    attempt_store.set("execution_start_time", start_time)
+    print(f"  ✓ Execution Start Time: {start_time}")
+
+    # 4. Custom configuration example
+    config = {
+        "timeout": 30000,
+        "retries": 3,
+        "environment": os.getenv("ENV", "development"),
+    }
+    attempt_store.set("config", config)
+    print(f"  ✓ Configuration stored: {config}")
+
+    # 5. Computed values example
+    user_agent = "Intuned-Bot/1.0"
+    attempt_store.set("user_agent", user_agent)
+    print(f"  ✓ User Agent: {user_agent}")
+
+    print("🔧 Setup Hook: Complete!\n")

--- a/python-examples/setup-hooks/pyproject.toml
+++ b/python-examples/setup-hooks/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "setup-hooks"
+version = "0.0.1"
+description = "Demonstrates setup hooks usage in Intuned"
+authors = [{ name = "Intuned", email = "service@intunedhq.com" }]
+requires-python = ">=3.12,<3.13"
+readme = "README.md"
+keywords = [
+    "Python",
+]
+dependencies = [
+    "playwright==1.56",
+    "intuned-runtime==1.3.14",
+    "intuned-browser==0.1.11",
+    "pydantic>=2.0.0",
+]
+
+[tool.uv]
+package = false

--- a/python-examples/setup-hooks/utils/types_and_schemas.py
+++ b/python-examples/setup-hooks/utils/types_and_schemas.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+from typing import Any
+
+
+class DemoHookParams(BaseModel):
+    """Parameters for demo-hook API"""
+
+    message: str | None = None
+
+
+class DataFromHook(BaseModel):
+    """Data retrieved from setup hook"""
+
+    cdp_url: str
+    api_name: str
+    api_parameters: Any  # Can be dict, string, or any type
+    execution_start_time: str
+    config: Any  # Can be any type
+    user_agent: str
+
+
+class HookDemoResult(BaseModel):
+    """Result returned from demo-hook API"""
+
+    message: str
+    data_from_hook: DataFromHook
+    execution_time: str
+    page_title: str

--- a/typescript-examples/README.md
+++ b/typescript-examples/README.md
@@ -18,6 +18,8 @@ Intuned sample projects in TypeScript.
 | [e-commerece-category](./e-commerece-category/) | E-commerce category and product scraper |
 | [hybrid-automation](./hybrid-automation/) | Hybrid automation combining Intuned Browser SDK with AI-powered tools like Stagehand and extractStructuredData |
 | [computer-use](./computer-use/) | AI-powered browser automation with Anthropic, OpenAI, and Gemini |
+| [cdp-connection](./cdp-connection/) | Basic example demonstrating Chrome DevTools Protocol (CDP) connection |
+| [setup-hooks](./setup-hooks/) | Demonstrates setup hooks for preparing data before API execution |
 | [jsdom-example](./jsdom-example/) | Web scraping with JSDOM for HTML parsing |
 | [captcha-solving-basic-example](./captcha-solving-basic-example/) | Captcha solving usage examples |
 | [captcha-solving-auth-example](./captcha-solving-auth-example/) | E-commerce scraper with captcha |

--- a/typescript-examples/cdp-connection/.env.example
+++ b/typescript-examples/cdp-connection/.env.example
@@ -1,0 +1,1 @@
+INTUNED_API_KEY=your_api_key_here

--- a/typescript-examples/cdp-connection/.gitignore
+++ b/typescript-examples/cdp-connection/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/typescript-examples/cdp-connection/.parameters/api/connect-to-cdp/default.json
+++ b/typescript-examples/cdp-connection/.parameters/api/connect-to-cdp/default.json
@@ -1,0 +1,3 @@
+{
+  "url": "https://books.toscrape.com/index.html"
+}

--- a/typescript-examples/cdp-connection/Intuned.jsonc
+++ b/typescript-examples/cdp-connection/Intuned.jsonc
@@ -1,0 +1,27 @@
+// For more information, see our Intuned settings reference
+// https://docs.intunedhq.com/docs/05-references/intuned-json
+{
+  "apiAccess": {
+    "enabled": true
+  },
+  "authSessions": {
+    "enabled": false
+  },
+  "replication": {
+    "maxConcurrentRequests": 1,
+    "size": "standard"
+  },
+  "metadata": {
+    "template": {
+      "name": "CDP Connection",
+      "description": "Basic example demonstrating how to connect to a browser using Chrome DevTools Protocol (CDP)",
+      "tags": ["cdp", "playwright", "browser-automation", "intuned-runtime-sdk", "intuned-runtime-sdk-setup-context-hook"]
+    },
+    "defaultRunPlaygroundInput": {
+      "apiName": "connect-to-cdp",
+      "parameters": {
+        "url": "https://example.com"
+      }
+    }
+  }
+}

--- a/typescript-examples/cdp-connection/Intuned.jsonc
+++ b/typescript-examples/cdp-connection/Intuned.jsonc
@@ -13,7 +13,7 @@
   },
   "metadata": {
     "template": {
-      "name": "CDP Connection",
+      "name": "cdp-connection",
       "description": "Basic example demonstrating how to connect to a browser using Chrome DevTools Protocol (CDP)"
     }
   }

--- a/typescript-examples/cdp-connection/README.md
+++ b/typescript-examples/cdp-connection/README.md
@@ -1,0 +1,234 @@
+# CDP Connection Example
+
+This template demonstrates how to connect to a browser using Chrome DevTools Protocol (CDP) with Intuned. It shows you how to:
+
+- Retrieve the CDP URL from Intuned runtime
+- Fetch browser information via CDP endpoints
+- Create CDP sessions and execute CDP commands
+- Understand WebDriver vs CDP protocols
+- Use Playwright with an existing CDP connection
+- Navigate pages and extract information
+
+## What is CDP?
+
+**Chrome DevTools Protocol (CDP)** is a low-level protocol that allows tools to instrument, inspect, debug, and profile Chromium-based browsers (Chrome, Edge, etc.). CDP provides deep access to browser internals and is the most powerful protocol for browser automation.
+
+**Key features of CDP:**
+- Chrome/Chromium-specific protocol
+- Direct access to browser DevTools features
+- Real-time debugging and profiling
+- Network interception and modification
+- Performance monitoring
+- JavaScript execution in any context
+- Screenshot and PDF generation
+- DOM manipulation and inspection
+
+## What is WebDriver?
+
+**WebDriver** is a W3C standard protocol for browser automation that works across different browsers (Chrome, Firefox, Safari, Edge). It's a higher-level, cross-browser API designed for testing and automation.
+
+**Key features of WebDriver:**
+- Cross-browser compatibility (W3C standard)
+- Browser-agnostic API
+- Session-based (uses session IDs)
+- Standardized commands
+- Less powerful than CDP but more portable
+
+## CDP vs WebDriver
+
+| Feature | CDP | WebDriver |
+|---------|-----|-----------|
+| **Browser Support** | Chrome/Chromium only | Cross-browser (Chrome, Firefox, Safari, Edge) |
+| **Protocol Type** | Low-level, Chrome-specific | High-level, standardized (W3C) |
+| **Power/Features** | Very powerful, deep browser access | Limited to standard automation commands |
+| **Use Cases** | Performance profiling, network inspection, debugging | Cross-browser testing, standard automation |
+| **Session Management** | No session IDs | Session-based with session IDs |
+| **API Stability** | Can change with Chrome versions | Stable W3C standard |
+
+**When to use CDP:**
+- Need Chrome/Edge-specific features
+- Require advanced capabilities (network interception, performance profiling)
+- Building Chrome-only tools
+- Need real-time DevTools access
+
+**When to use WebDriver:**
+- Need cross-browser support
+- Standard automation tasks
+- Testing across multiple browsers
+- Prefer stable, standardized API
+
+In this example, we use **CDP** because Intuned provides a CDP connection, giving you access to powerful Chrome-specific features. Playwright uses CDP under the hood for Chromium browsers.
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out the
+- Intuned docs [here](https://docs.intunedhq.com/docs/00-getting-started/introduction)
+- CLI docs [here](https://docs.intunedhq.com/docs/05-references/cli)
+- Intuned.jsonc docs [here](https://docs.intunedhq.com/docs/05-references/intuned-json#intuned-json)
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# npm
+npm install
+
+# yarn
+yarn
+```
+
+> **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
+
+### Run an API
+
+```bash
+# npm
+npm run intuned run api connect-to-cdp .parameters/api/connect-to-cdp/default.json
+
+# yarn
+yarn intuned run api connect-to-cdp .parameters/api/connect-to-cdp/default.json
+```
+
+### Save project
+
+```bash
+# npm
+npm run intuned run save
+
+# yarn
+yarn intuned run save
+```
+
+Reference for saving project [here](https://docs.intunedhq.com/docs/02-features/local-development-cli#use-runtime-sdk-and-browser-sdk-helpers)
+
+### Deploy project
+```bash
+# npm
+npm run intuned deploy
+
+# yarn
+yarn intuned deploy
+
+```
+
+### `@intuned/browser`: Intuned Browser SDK
+
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/intuned-sdk/overview).
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── api/                      # Your API endpoints
+│   └── connect-to-cdp.ts     # CDP connection example
+├── hooks/                    # Setup hooks that run before API execution
+│   └── setupContext.ts       # Captures CDP URL from Intuned runtime
+├── utils/                    # Utility functions and schemas
+│   └── typesAndSchemas.ts    # Zod schemas and TypeScript types
+├── .parameters/              # Parameter files for testing APIs
+│   └── api/                  # API parameters folder
+│       └── connect-to-cdp/   # Parameters for CDP connection API
+│           └── default.json  # Default parameters (URL to navigate to)
+└── Intuned.jsonc             # Intuned project configuration file
+```
+
+## Envs
+
+This project requires the following environment variables:
+
+- `INTUNED_API_KEY`: Your Intuned API key for authentication. Get it from [Intuned Dashboard](https://dashboard.intunedhq.com)
+
+## How It Works
+
+The `connect-to-cdp.ts` API demonstrates the following:
+
+1. **Setup Hook**: The `hooks/setupContext.ts` captures the CDP URL from Intuned's runtime and stores it in `attemptStore`
+2. **Parameter Validation**: Uses Zod schemas to validate input parameters (`url`) with `safeParse()` for type-safe validation
+3. **Retrieve CDP URL**: Gets the CDP URL from `attemptStore` (automatically provided by Intuned)
+4. **Fetch Browser Info**: Makes HTTP requests to CDP endpoints to get browser version, protocol version, and WebSocket URL
+5. **Create CDP Session**: Creates a CDP session using `context.newCDPSession(page)` to execute CDP commands
+6. **Get WebDriver Capabilities**: Demonstrates getting browser capabilities and explains the difference between WebDriver and CDP
+7. **Use Playwright**: The `page` object provided by Intuned is already connected via CDP - no additional setup needed
+8. **Navigate & Extract**: Demonstrates basic navigation and information extraction from the page
+
+## Parameter Validation with Zod
+
+This project uses Zod for runtime type validation and schema validation. The schemas are defined in `utils/typesAndSchemas.ts`:
+
+```typescript
+import { connectToCdpParamsSchema } from "../utils/typesAndSchemas.js";
+
+// Validate parameters
+const validationResult = connectToCdpParamsSchema.safeParse(params);
+
+if (!validationResult.success) {
+  // Handle validation errors
+  throw new Error(`Parameter validation failed: ${errors}`);
+}
+
+const { url } = validationResult.data;
+```
+
+**Benefits of Zod validation:**
+- Runtime type safety
+- Clear error messages
+- Automatic TypeScript type inference
+- URL format validation
+- Required field validation
+
+## CDP Sessions and Commands
+
+### Creating a CDP Session
+
+```typescript
+const cdpSession = await context.newCDPSession(page);
+```
+
+A CDP session allows you to send low-level CDP commands directly to the browser.
+
+### Example CDP Commands
+
+```typescript
+// Get browser version
+const version = await cdpSession.send("Browser.getVersion");
+
+// Enable network tracking
+await cdpSession.send("Network.enable");
+
+// Get performance metrics
+const metrics = await cdpSession.send("Performance.getMetrics");
+
+// Take a screenshot
+const screenshot = await cdpSession.send("Page.captureScreenshot");
+
+// Always detach when done
+await cdpSession.detach();
+```
+
+### Common CDP Domains
+
+- **Browser**: Browser-level operations
+- **Page**: Page-level operations (navigation, screenshots)
+- **Network**: Network interception and monitoring
+- **Performance**: Performance metrics and profiling
+- **Runtime**: JavaScript execution
+- **DOM**: DOM manipulation and inspection
+- **Debugger**: JavaScript debugging
+- **Emulation**: Device and media emulation
+
+## CDP Endpoints
+
+When you have the CDP URL, you can access various CDP endpoints:
+
+- `GET {cdpUrl}/json/version` - Get browser version information
+- `GET {cdpUrl}/json` - List all available targets (pages, service workers, etc.)
+- `GET {cdpUrl}/json/protocol` - Get the full protocol definition
+- `WebSocket {webSocketDebuggerUrl}` - Connect via WebSocket for real-time CDP communication
+
+## Learn More
+
+- [Chrome DevTools Protocol Documentation](https://chromedevtools.github.io/devtools-protocol/)
+- [Playwright CDP Documentation](https://playwright.dev/docs/api/class-cdpsession)
+- [Intuned Runtime SDK](https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/runtime/variables/attemptStore)

--- a/typescript-examples/cdp-connection/api/connect-to-cdp.ts
+++ b/typescript-examples/cdp-connection/api/connect-to-cdp.ts
@@ -1,0 +1,136 @@
+import type { Page, BrowserContext } from "playwright";
+import { attemptStore } from "@intuned/runtime";
+import {
+  connectToCdpParamsSchema,
+  type ConnectToCdpParams,
+  type BrowserInfo,
+  type PageInfo,
+  type WebDriverInfo,
+  type CDPConnectionResult,
+} from "../utils/typesAndSchemas";
+
+/**
+ * Fetches browser information from the CDP endpoint
+ */
+async function getBrowserInfo(cdpUrl: string): Promise<BrowserInfo> {
+  const versionUrl = cdpUrl.endsWith("/")
+    ? `${cdpUrl}json/version`
+    : `${cdpUrl}/json/version`;
+
+  const response = await fetch(versionUrl);
+  const data = await response.json();
+
+  return {
+    browserVersion: data["Browser"],
+    protocolVersion: data["Protocol-Version"],
+    userAgent: data["User-Agent"],
+    webSocketDebuggerUrl: data.webSocketDebuggerUrl,
+  };
+}
+
+export default async function handler(
+  params: ConnectToCdpParams,
+  page: Page,
+  context: BrowserContext
+): Promise<CDPConnectionResult> {
+  console.log("=== CDP Connection Example ===\n");
+
+  // Validate parameters using Zod schema
+  const validationResult = connectToCdpParamsSchema.safeParse(params);
+
+  if (!validationResult.success) {
+    const errors = validationResult.error.errors
+      .map((err) => `${err.path.join(".")}: ${err.message}`)
+      .join(", ");
+    throw new Error(`Parameter validation failed: ${errors}`);
+  }
+
+  const { url } = validationResult.data;
+
+  // Get CDP URL from Intuned's runtime (provided via setupContext hook)
+  const cdpUrl = attemptStore.get("cdpUrl") as string;
+
+  console.log(`✓ CDP URL: ${cdpUrl}`);
+
+  // Step 1: Fetch browser information via CDP
+  const browserInfo = await getBrowserInfo(cdpUrl);
+  console.log("\n✓ Browser Information:");
+  console.log(`  - Browser Version: ${browserInfo.browserVersion}`);
+  console.log(`  - Protocol Version: ${browserInfo.protocolVersion}`);
+  console.log(`  - User Agent: ${browserInfo.userAgent}`);
+  console.log(`  - WebSocket URL: ${browserInfo.webSocketDebuggerUrl}`);
+
+  // Step 2: Get WebDriver capabilities using CDP
+  // Create a CDP session to execute CDP commands
+  const cdpSession = await context.newCDPSession(page);
+
+  console.log("\n✓ WebDriver Information:");
+  console.log("  WebDriver is a W3C standard protocol for browser automation.");
+  console.log(
+    "  CDP (Chrome DevTools Protocol) is Chrome-specific and more powerful."
+  );
+
+  // Get browser capabilities through CDP
+  const browserCapabilities = await cdpSession.send("Browser.getVersion");
+
+  const webDriverInfo: WebDriverInfo = {
+    capabilities: {
+      browserName: "chromium",
+      browserVersion: browserCapabilities.product,
+      platformName: process.platform,
+      cdpEnabled: true,
+      webDriverBiDiSupported: false, // Playwright uses CDP, not WebDriver BiDi by default
+    },
+    sessionId: undefined, // CDP doesn't use WebDriver session IDs
+  };
+
+  console.log(`  - Browser Name: ${webDriverInfo.capabilities.browserName}`);
+  console.log(
+    `  - Browser Version: ${webDriverInfo.capabilities.browserVersion}`
+  );
+  console.log(`  - Platform: ${webDriverInfo.capabilities.platformName}`);
+  console.log(`  - CDP Enabled: ${webDriverInfo.capabilities.cdpEnabled}`);
+  console.log(
+    `  - WebDriver BiDi: ${webDriverInfo.capabilities.webDriverBiDiSupported}`
+  );
+
+  // Close CDP session
+  await cdpSession.detach();
+
+  // Step 3: Use the Playwright page (already connected via CDP)
+  // The page object is already connected to the browser via CDP
+  console.log("\n✓ Playwright page is ready and connected via CDP");
+
+  // Step 4: Navigate to a URL
+  console.log(`\n✓ Navigating to: ${url}`);
+  await page.goto(url, { waitUntil: "networkidle" });
+
+  // Step 5: Get page information
+  const title = await page.title();
+  const currentUrl = page.url();
+  const viewport = page.viewportSize();
+
+  const pageInfo: PageInfo = {
+    title,
+    url: currentUrl,
+    viewport: viewport || { width: 0, height: 0 },
+  };
+
+  console.log("\n✓ Page Information:");
+  console.log(`  - Title: ${pageInfo.title}`);
+  console.log(`  - URL: ${pageInfo.url}`);
+  console.log(
+    `  - Viewport: ${pageInfo.viewport.width}x${pageInfo.viewport.height}`
+  );
+
+  console.log("\n✓ CDP connection successful!\n");
+
+  return {
+    message:
+      "Successfully connected to browser via CDP and retrieved information",
+    cdpUrl,
+    browserInfo,
+    pageInfo,
+    webDriverInfo,
+  };
+}

--- a/typescript-examples/cdp-connection/api/connect-to-cdp.ts
+++ b/typescript-examples/cdp-connection/api/connect-to-cdp.ts
@@ -1,5 +1,6 @@
 import type { Page, BrowserContext } from "playwright";
 import { attemptStore } from "@intuned/runtime";
+import { goToUrl } from "@intuned/browser";
 import {
   connectToCdpParamsSchema,
   type ConnectToCdpParams,
@@ -103,25 +104,23 @@ export default async function handler(
 
   // Step 4: Navigate to a URL
   console.log(`\n✓ Navigating to: ${url}`);
-  await page.goto(url, { waitUntil: "networkidle" });
+  await goToUrl({
+    page,
+    url,
+  });
 
   // Step 5: Get page information
   const title = await page.title();
   const currentUrl = page.url();
-  const viewport = page.viewportSize();
 
   const pageInfo: PageInfo = {
     title,
-    url: currentUrl,
-    viewport: viewport || { width: 0, height: 0 },
+    url: currentUrl
   };
 
   console.log("\n✓ Page Information:");
   console.log(`  - Title: ${pageInfo.title}`);
   console.log(`  - URL: ${pageInfo.url}`);
-  console.log(
-    `  - Viewport: ${pageInfo.viewport.width}x${pageInfo.viewport.height}`
-  );
 
   console.log("\n✓ CDP connection successful!\n");
 

--- a/typescript-examples/cdp-connection/hooks/setupContext.ts
+++ b/typescript-examples/cdp-connection/hooks/setupContext.ts
@@ -1,0 +1,13 @@
+import { attemptStore } from "@intuned/runtime";
+
+export default async function setupContext({
+  cdpUrl,
+  apiName,
+  apiParameters,
+}: {
+  cdpUrl: string;
+  apiName: string;
+  apiParameters: any;
+}) {
+  attemptStore.set("cdpUrl", cdpUrl);
+}

--- a/typescript-examples/cdp-connection/package.json
+++ b/typescript-examples/cdp-connection/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cdp-connection",
+  "version": "1.0.0",
+  "description": "Basic example demonstrating CDP connection with Intuned",
+  "tags": [
+    "cdp",
+    "playwright",
+    "browser-automation"
+  ],
+  "main": "index.js",
+  "scripts": {
+    "intuned": "intuned"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@intuned/browser": "0.1.8",
+    "@intuned/runtime": "1.3.14",
+    "@types/node": "^20.10.3",
+    "playwright": "~1.56.0",
+    "zod": "^3.22.4"
+  }
+}

--- a/typescript-examples/cdp-connection/tsconfig.json
+++ b/typescript-examples/cdp-connection/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "target": "ES2021",
+    "outDir": "./dist",
+    "sourceMap": false,
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/typescript-examples/cdp-connection/utils/typesAndSchemas.ts
+++ b/typescript-examples/cdp-connection/utils/typesAndSchemas.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+// Params schema for connect-to-cdp API
+export const connectToCdpParamsSchema = z.object({
+  url: z.string().url("Must be a valid URL").min(1, "URL is required"),
+});
+
+// Browser Info schema
+export const browserInfoSchema = z.object({
+  browserVersion: z.string(),
+  protocolVersion: z.string(),
+  userAgent: z.string(),
+  webSocketDebuggerUrl: z.string().url(),
+});
+
+// Page Info schema
+export const pageInfoSchema = z.object({
+  title: z.string(),
+  url: z.string().url(),
+  viewport: z.object({
+    width: z.number(),
+    height: z.number(),
+  }),
+});
+
+// WebDriver Info schema
+export const webDriverInfoSchema = z.object({
+  capabilities: z.record(z.any()),
+  sessionId: z.string().optional(),
+});
+
+// CDP Connection Result schema
+export const cdpConnectionResultSchema = z.object({
+  message: z.string(),
+  cdpUrl: z.string().url(),
+  browserInfo: browserInfoSchema,
+  pageInfo: pageInfoSchema,
+  webDriverInfo: webDriverInfoSchema,
+});
+
+// Type exports inferred from schemas
+export type ConnectToCdpParams = z.infer<typeof connectToCdpParamsSchema>;
+export type BrowserInfo = z.infer<typeof browserInfoSchema>;
+export type PageInfo = z.infer<typeof pageInfoSchema>;
+export type WebDriverInfo = z.infer<typeof webDriverInfoSchema>;
+export type CDPConnectionResult = z.infer<typeof cdpConnectionResultSchema>;

--- a/typescript-examples/cdp-connection/utils/typesAndSchemas.ts
+++ b/typescript-examples/cdp-connection/utils/typesAndSchemas.ts
@@ -16,11 +16,7 @@ export const browserInfoSchema = z.object({
 // Page Info schema
 export const pageInfoSchema = z.object({
   title: z.string(),
-  url: z.string().url(),
-  viewport: z.object({
-    width: z.number(),
-    height: z.number(),
-  }),
+  url: z.string().url()
 });
 
 // WebDriver Info schema

--- a/typescript-examples/setup-hooks/.env.example
+++ b/typescript-examples/setup-hooks/.env.example
@@ -1,0 +1,1 @@
+INTUNED_API_KEY=your_api_key_here

--- a/typescript-examples/setup-hooks/.gitignore
+++ b/typescript-examples/setup-hooks/.gitignore
@@ -1,0 +1,51 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production builds
+/build
+/dist
+/.next/
+/out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime/temporary files
+.cache
+.parcel-cache
+*.tsbuildinfo
+
+# Coverage
+/coverage
+.nyc_output
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyc
+.Python
+build/
+*.egg-info/
+.venv/
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/

--- a/typescript-examples/setup-hooks/.parameters/api/demo-hook/default.json
+++ b/typescript-examples/setup-hooks/.parameters/api/demo-hook/default.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello from Setup Hooks!"
+}

--- a/typescript-examples/setup-hooks/Intuned.jsonc
+++ b/typescript-examples/setup-hooks/Intuned.jsonc
@@ -13,8 +13,8 @@
   },
   "metadata": {
     "template": {
-      "name": "CDP Connection",
-      "description": "Basic example demonstrating how to connect to a browser using Chrome DevTools Protocol (CDP)"
+      "name": "Setup Hooks",
+      "description": "Demonstrates how to use setup hooks to prepare data and configuration before API execution"
     }
   }
 }

--- a/typescript-examples/setup-hooks/Intuned.jsonc
+++ b/typescript-examples/setup-hooks/Intuned.jsonc
@@ -13,7 +13,7 @@
   },
   "metadata": {
     "template": {
-      "name": "Setup Hooks",
+      "name": "setup-hooks",
       "description": "Demonstrates how to use setup hooks to prepare data and configuration before API execution"
     }
   }

--- a/typescript-examples/setup-hooks/README.md
+++ b/typescript-examples/setup-hooks/README.md
@@ -1,0 +1,68 @@
+# setup-hooks Intuned project
+
+Example demonstrating how to use setup hooks in Intuned to prepare data and configuration before your API executes
+
+## Getting Started
+
+To get started developing browser automation projects with Intuned, check out our [concepts and terminology](https://docs.intunedhq.com/docs/getting-started/conceptual-guides/core-concepts#runs%3A-executing-your-automations).
+
+
+## Development
+
+> **_NOTE:_**  All commands support `--help` flag to get more information about the command and its arguments and options.
+
+### Install dependencies
+```bash
+# npm
+npm install
+
+# yarn
+yarn
+```
+
+> **_NOTE:_**  If you are using `npm`, make sure to pass `--` when using options with the `intuned` command.
+
+### Run an API
+```bash
+# npm
+npm run intuned run api demo-hook .parameters/api/demo-hook/default.json
+
+# yarn
+yarn intuned run api demo-hook .parameters/api/demo-hook/default.json
+```
+
+### Deploy project
+```bash
+# npm
+npm run intuned deploy
+
+# yarn
+yarn intuned deploy
+```
+
+
+
+
+### `@intuned/browser`: Intuned Browser SDK
+
+This project uses Intuned browser SDK. For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+
+
+
+
+## Project Structure
+The project structure is as follows:
+```
+/
+├── api/                      # Your API endpoints
+│   └── demo-hook.ts          # Demo API showing hook data usage
+├── hooks/                    # Setup hooks executed before API runs
+│   └── setupContext.ts       # Main setup hook
+├── utils/                    # Utility functions and schemas
+│   └── typesAndSchemas.ts    # Zod schemas and TypeScript types
+├── .parameters/              # Parameter files for testing APIs
+│   └── api/                  # API parameters folder
+│       └── demo-hook/        # Parameters for demo API
+│           └── default.json  # Default parameters
+└── Intuned.jsonc             # Intuned project configuration file
+```

--- a/typescript-examples/setup-hooks/api/demo-hook.ts
+++ b/typescript-examples/setup-hooks/api/demo-hook.ts
@@ -1,0 +1,76 @@
+import type { Page, BrowserContext } from "playwright";
+import { attemptStore } from "@intuned/runtime";
+import { goToUrl } from "@intuned/browser";
+import {
+  demoHookParamsSchema,
+  type DemoHookParams,
+  type HookDemoResult,
+} from "../utils/typesAndSchemas";
+
+export default async function handler(
+  params: DemoHookParams,
+  page: Page,
+  _context: BrowserContext
+): Promise<HookDemoResult> {
+  // Validate parameters using Zod schema
+  const validationResult = demoHookParamsSchema.safeParse(params);
+
+  if (!validationResult.success) {
+    const errors = validationResult.error.errors
+      .map((err) => `${err.path.join(".")}: ${err.message}`)
+      .join(", ");
+    throw new Error(`Parameter validation failed: ${errors}`);
+  }
+
+  const { message = "Hello from Setup Hooks!" } = validationResult.data;
+  console.log("=== Setup Hooks Demo API ===\n");
+
+  // Step 1: Retrieve data that was stored by the setup hook
+  console.log("📦 Retrieving data from setup hook...\n");
+
+  const cdpUrl = attemptStore.get("cdpUrl") as string;
+  const apiName = attemptStore.get("apiName") as string;
+  const apiParameters = attemptStore.get("apiParameters");
+  const executionStartTime = attemptStore.get("executionStartTime") as string;
+  const config = attemptStore.get("config");
+  const userAgent = attemptStore.get("userAgent") as string;
+
+  console.log("✓ Data retrieved from attemptStore:");
+  console.log(`  - CDP URL: ${cdpUrl}`);
+  console.log(`  - API Name: ${apiName}`);
+  console.log(`  - Execution Start: ${executionStartTime}`);
+  console.log(`  - User Agent: ${userAgent}`);
+  console.log(`  - Config:`, config);
+
+  // Step 2: Use the page (connected via CDP thanks to the hook)
+  console.log("\n🌐 Navigating to example.com...");
+  await goToUrl({
+    page,
+    url: "https://example.com",
+  })
+  const pageTitle = await page.title();
+  console.log(`✓ Page Title: ${pageTitle}`);
+
+  // Step 3: Calculate execution time
+  const endTime = new Date();
+  const startTime = new Date(executionStartTime);
+  const executionMs = endTime.getTime() - startTime.getTime();
+  const executionTime = `${executionMs}ms`;
+  console.log(`\n⏱️  Total Execution Time: ${executionTime}`);
+
+  console.log("\n✅ Setup Hooks Demo Complete!\n");
+
+  return {
+    message,
+    dataFromHook: {
+      cdpUrl,
+      apiName,
+      apiParameters,
+      executionStartTime,
+      config,
+      userAgent,
+    },
+    executionTime,
+    pageTitle,
+  };
+}

--- a/typescript-examples/setup-hooks/hooks/setupContext.ts
+++ b/typescript-examples/setup-hooks/hooks/setupContext.ts
@@ -1,0 +1,54 @@
+import { attemptStore } from "@intuned/runtime";
+
+/**
+ * Setup Hook - Runs before your API executes
+ *
+ * Purpose: Prepare data, configuration, or state that your API will need
+ *
+ * This hook demonstrates:
+ * 1. Storing the CDP URL for browser connection
+ * 2. Storing API metadata (name and parameters)
+ * 3. Adding custom configuration or computed values
+ * 4. Setting up timestamps for tracking
+ */
+export default async function setupContext({
+  cdpUrl,
+  apiName,
+  apiParameters,
+}: {
+  cdpUrl: string;
+  apiName: string;
+  apiParameters: any;
+}) {
+  console.log("🔧 Setup Hook: Preparing environment...");
+
+  // 1. Store CDP URL for browser operations
+  attemptStore.set("cdpUrl", cdpUrl);
+  console.log(`  ✓ CDP URL stored: ${cdpUrl}`);
+
+  // 2. Store API metadata for reference
+  attemptStore.set("apiName", apiName);
+  attemptStore.set("apiParameters", apiParameters);
+  console.log(`  ✓ API Name: ${apiName}`);
+  console.log(`  ✓ Parameters:`, apiParameters);
+
+  // 3. Add execution timestamp
+  const startTime = new Date().toISOString();
+  attemptStore.set("executionStartTime", startTime);
+  console.log(`  ✓ Execution Start Time: ${startTime}`);
+
+  // 4. Custom configuration example
+  const config = {
+    timeout: 30000,
+    retries: 3,
+  };
+  attemptStore.set("config", config);
+  console.log(`  ✓ Configuration stored:`, config);
+
+  // 5. Computed values example
+  const userAgent = "Intuned-Bot/1.0";
+  attemptStore.set("userAgent", userAgent);
+  console.log(`  ✓ User Agent: ${userAgent}`);
+
+  console.log("🔧 Setup Hook: Complete!\n");
+}

--- a/typescript-examples/setup-hooks/package.json
+++ b/typescript-examples/setup-hooks/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "cdp-connection",
+  "name": "setup-hooks",
   "version": "1.0.0",
-  "description": "Basic example demonstrating CDP connection with Intuned",
+  "description": "Demonstrates setup hooks usage in Intuned",
   "tags": [],
   "main": "index.js",
   "scripts": {

--- a/typescript-examples/setup-hooks/tsconfig.json
+++ b/typescript-examples/setup-hooks/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "target": "ES2021",
+    "outDir": "./dist",
+    "sourceMap": false,
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/typescript-examples/setup-hooks/utils/typesAndSchemas.ts
+++ b/typescript-examples/setup-hooks/utils/typesAndSchemas.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+// Params schema for demo-hook API
+export const demoHookParamsSchema = z.object({
+  message: z.string().optional(),
+});
+
+// Data from hook schema
+export const dataFromHookSchema = z.object({
+  cdpUrl: z.string(),
+  apiName: z.string(),
+  apiParameters: z.any(),
+  executionStartTime: z.string(),
+  config: z.any(),
+  userAgent: z.string(),
+});
+
+// Hook demo result schema
+export const hookDemoResultSchema = z.object({
+  message: z.string(),
+  dataFromHook: dataFromHookSchema,
+  executionTime: z.string(),
+  pageTitle: z.string(),
+});
+
+// Type exports inferred from schemas
+export type DemoHookParams = z.infer<typeof demoHookParamsSchema>;
+export type DataFromHook = z.infer<typeof dataFromHookSchema>;
+export type HookDemoResult = z.infer<typeof hookDemoResultSchema>;


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [x] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [x] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [x] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [x] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [x] Main README and language-specific README updated if adding/modifying examples

