### PR TITLE
fix browser-use

### DIFF
--- a/python-examples/browser-use/Intuned.jsonc
+++ b/python-examples/browser-use/Intuned.jsonc
@@ -1,6 +1,8 @@
 // For more information, see our Intuned settings reference
 // https://docs.intunedhq.com/docs/05-references/intuned-json
 {
+  // "workspaceId": "your-workspace-id", // Add your workspace ID here for local development
+  // "projectName": "your-project-name", // Add your project name here for local development
   "apiAccess": {
     "enabled": true
   },
@@ -14,7 +16,19 @@
   "metadata": {
     "template": {
       "name": "browser-use",
-      "description": "AI-powered browser automation using browser-use library"
+      "description": "AI-powered browser automation using browser-use library",
+      "tags": ["browser-use", "ai-powered-automation", "browser-automation"]
+    },
+    "defaultRunPlaygroundInput": {
+      "apiName": "purchase-item",
+      "parameters": {
+        "username": "standard_user",
+        "password": "secret_sauce",
+        "product_name": "Sauce Labs Backpack",
+        "first_name": "John",
+        "last_name": "Doe",
+        "zip_code": "0000"
+      }
     }
   }
 }

--- a/python-examples/browser-use/README.md
+++ b/python-examples/browser-use/README.md
@@ -4,9 +4,7 @@ This example demonstrates how to integrate [Browser Use](https://github.com/brow
 
 ## Run on Intuned
 
-Open this project in Intuned by clicking the button below.
-
-<a href="https://app.intuned.io?repo=https://github.com/Intuned/cookbook/tree/main/python-examples/browser-use" target="_blank" rel="noreferrer"><img src="https://cdn1.intuned.io/button.svg" alt="Run on Intuned"></a>
+[![Run on Intuned](https://cdn1.intuned.io/button.svg)](https://app.intuned.io?repo=https://github.com/Intuned/cookbook/tree/main/python-examples/browser-use)
 
 ## What This Example Does
 
@@ -32,7 +30,7 @@ The `hooks/setup_context.py` file runs before every API call and creates a Brows
 The `api/purchase-item.py` handler receives Intuned's Playwright `page` object and also uses the Browser Use browser.
 ## Parameters
 
-The API requires the following parameters:
+The API template example uses the following parameters:
 
 ```json
 {
@@ -47,10 +45,46 @@ The API requires the following parameters:
 
 ## Getting Started
 
+**Important:** This example uses [Browser Use](https://github.com/browser-use/browser-use), an AI-powered browser automation tool that requires Intuned's AI gateway. The AI gateway requires the project to be saved before running.
+
+### Setup
+
+To run this example locally, you need to set up your Intuned workspace:
+
+1. **Create a workspace** - Follow the [workspace management guide](https://docs.intunedhq.com/docs/03-how-to/manage/manage-workspace) to create your Intuned workspace
+
+2. **Get your API key** - Generate an API key from the [API keys page](https://docs.intunedhq.com/docs/03-how-to/manage/manage-api-keys#how-to-manage-api-keys) in your Intuned dashboard
+
+3. **Configure workspace ID** - Add your workspace ID and Project Name to `Intuned.jsonc`:
+   ```jsonc
+   {
+     "workspaceId": "your-workspace-id",
+     "projectName": "your-project-name"
+     // ... rest of config
+   }
+   ```
+
+4. **Set environment variable** - Add your API key as an environment variable:
+   ```bash
+   export INTUNED_API_KEY=your-api-key
+   ```
+
 ### Install Dependencies
 ```bash
 uv sync
 ```
+
+### Initialize Project
+
+Run the save command to upload your project and set up the required `.env` file:
+
+```bash
+uv run intuned save
+```
+
+This configures your local environment and prepares the AI gateway for Browser Use.
+
+Reference for saving project [here](https://docs.intunedhq.com/docs/02-features/local-development-cli#use-runtime-sdk-and-browser-sdk-helpers)
 
 ### Run the API Locally
 ```bash


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

