### PR TITLE
Browser SDK Showcase templates Fixes

### DIFF
--- a/python-examples/auth-with-secret-otp/auth-sessions-instances/test-auth-session/metadata.json
+++ b/python-examples/auth-with-secret-otp/auth-sessions-instances/test-auth-session/metadata.json
@@ -1,1 +1,11 @@
-{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{}}
+{
+    "createdAt": "2025-01-01T00:00:00.000Z",
+    "updatedAt": "2025-01-01T00:00:00.000Z",
+    "authSessionId": "test-auth-session",
+    "authSessionType": "API",
+    "authSessionInput": {
+      "username": "demo@email.com",
+      "password": "DemoUser2024!",
+      "secret": "JBSWY3DPEHPK3PXP"
+    }
+  }

--- a/python-examples/browser-sdk-showcase/README.md
+++ b/python-examples/browser-sdk-showcase/README.md
@@ -170,8 +170,8 @@ uv run intuned deploy
 
 ### File Operations
 - **download-file**: Download files from URLs or user interactions
-- **upload-file-to-s3**: Upload files to S3 buckets
-- **save-file-to-s3**: Save content directly to S3
+- **upload-file-to-s3**: Upload files to S3 (uses Intuned's managed bucket via gateway by default, or your own S3 with credentials)
+- **save-file-to-s3**: Save content directly to S3 (uses Intuned's managed bucket via gateway by default, or your own S3 with credentials)
 
 ### Utilities
 - **process-date**: Parse various date formats into standardized format

--- a/python-examples/browser-sdk-showcase/api/ai/extract-structured-data.py
+++ b/python-examples/browser-sdk-showcase/api/ai/extract-structured-data.py
@@ -34,8 +34,13 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
         data_schema=Book,  # Pass Pydantic model directly, or use a normal json schema dictionary too.
         prompt="Extract book details from this page",
         enable_cache=False,  # To enable cache, you must run in Intuned context (IDE/CLI) and save the project, with the correct API credentials.
-        max_retries=3,
     )
     print(f"Found product: {product['name']} - {product['price']}")
 
-    return "Success"
+    return {
+        "name": product["name"],
+        "price": product["price"],
+        "description": product["description"],
+        "in_stock": product.get("in_stock", None),
+        "rating": product.get("rating", None),
+    }

--- a/python-examples/browser-sdk-showcase/api/click-until-exhausted.py
+++ b/python-examples/browser-sdk-showcase/api/click-until-exhausted.py
@@ -17,3 +17,7 @@ async def automation(page: Page, params: Params, **_kwargs):
         max_clicks=20
     )
     # Will keep clicking the button until the button disappears or is disabled or the max_clicks is reached.
+    elements = await page.locator("main main slot slot div").count()
+    return {
+        "number_of_elements": elements,
+    }

--- a/python-examples/browser-sdk-showcase/api/extract-markdown.py
+++ b/python-examples/browser-sdk-showcase/api/extract-markdown.py
@@ -17,4 +17,8 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     markdown = await extract_markdown(header_locator) # Extract markdown from the header locator.
     print("Markdown content of the header:")
     print(markdown)
-    return markdown
+    return {
+        "markdown": markdown,
+        "source": "h1 header",
+        "url": page.url
+    }

--- a/python-examples/browser-sdk-showcase/api/go-to-url.py
+++ b/python-examples/browser-sdk-showcase/api/go-to-url.py
@@ -27,4 +27,10 @@ async def automation(page: Page, params: Params, **_kwargs):
     )
 
     # Start your automation here, the page is already loaded and ready to use.
-    return "Success"
+    title = await page.title()
+    url = page.url
+    
+    return {
+        "title": title,
+        "url": url,
+    }

--- a/python-examples/browser-sdk-showcase/api/resolve-url.py
+++ b/python-examples/browser-sdk-showcase/api/resolve-url.py
@@ -14,28 +14,32 @@ class Params(TypedDict):
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
     # Resolve a relative URL to an absolute URL
-    absolute_url = await resolve_url(
+    url_with_base = await resolve_url(
         url="/api/users",
         base_url="https://example.com"
     )
     print("Result of resolving relative URL to absolute URL:")
-    print(absolute_url)
+    print(url_with_base)
 
     # Resolve relative URL from the current page
     await page.goto("https://intunedhq.com")
-    absolute_url = await resolve_url(
+    url_from_page = await resolve_url(
         url="/blog/intuned-act-3",
         page=page
     )
     print("Result of resolving relative URL from the current page:")
-    print(absolute_url)
+    print(url_from_page)
 
     # Resolve relative URL from an anchor tag
     await page.goto("https://intunedhq.com")
-    absolute_url = await resolve_url(
+    url_from_anchor = await resolve_url(
         url=page.locator("a:has-text('Schedule a demo')")
     )
     print("Result of resolving relative URL from an anchor tag:")
-    print(absolute_url)
+    print(url_from_anchor)
 
-    return "Success"
+    return {
+        "url_with_base": url_with_base,
+        "url_from_page": url_from_page,
+        "url_from_anchor": url_from_anchor
+    }

--- a/python-examples/browser-sdk-showcase/api/sanitize-html.py
+++ b/python-examples/browser-sdk-showcase/api/sanitize-html.py
@@ -21,4 +21,6 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     sanitized_html = sanitize_html(html, remove_styles=remove_styles, max_attribute_length=max_attribute_length)
     print("Sanitized HTML:")
     print(sanitized_html)
-    return sanitized_html
+    return {
+        "sanitized_html": sanitized_html,
+    }

--- a/python-examples/browser-sdk-showcase/api/save-file-to-s3.py
+++ b/python-examples/browser-sdk-showcase/api/save-file-to-s3.py
@@ -18,4 +18,8 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     )
     signed_url = await uploaded_file.get_signed_url()
     print(f"Signed URL: {signed_url}")
-    return signed_url
+    return {
+        "file_name": uploaded_file.file_name,
+        "signed_url": signed_url,
+        "message": "File uploaded successfully to S3"
+    }

--- a/python-examples/browser-sdk-showcase/api/scroll-to-load-content.py
+++ b/python-examples/browser-sdk-showcase/api/scroll-to-load-content.py
@@ -24,5 +24,9 @@ async def automation(page: Page, params: Params, **_kwargs):
         max_scrolls=max_scrolls,
     )
     # Will keep scrolling until the page has loaded all content or the max_scrolls is reached.
+    elements = await page.locator("main slot slot slot div").count() 
+    
 
-    return "Success"
+    return {
+        "number_of_elements": elements,
+    }

--- a/python-examples/browser-sdk-showcase/api/upload-file-to-s3.py
+++ b/python-examples/browser-sdk-showcase/api/upload-file-to-s3.py
@@ -20,6 +20,9 @@ async def automation(page: Page, params: Params, **_kwargs):
         content_type="application/pdf",
     )
     signed_url = await uploaded_file.get_signed_url()
-    print("Signed URL:")
-    print(signed_url)
-    return signed_url
+    print("Signed URL:", signed_url)
+    return {
+        "file_name": uploaded_file.file_name,
+        "signed_url": signed_url,
+        "message": "File uploaded successfully to S3"
+    }

--- a/python-examples/browser-sdk-showcase/api/validate-data-using-schema.py
+++ b/python-examples/browser-sdk-showcase/api/validate-data-using-schema.py
@@ -32,4 +32,8 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     validate_data_using_schema(upload_data, upload_schema)
     # Validation passes with Attachment type, it also validates Pydantic Attachment type.
     print("Validation passed")
-    return "Validation passed"
+    return {
+        "status": "valid",
+        "message": "Data validation passed successfully",
+        "validated_data": upload_data
+    }

--- a/python-examples/captcha-solving-auth-example/auth-sessions-instances/test-auth-session/metadata.json
+++ b/python-examples/captcha-solving-auth-example/auth-sessions-instances/test-auth-session/metadata.json
@@ -1,1 +1,4 @@
-{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{}}
+{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{
+    "username": "demo@email.com",
+    "password": "password"
+  }}

--- a/python-examples/computer-use/hooks/setup_context.py
+++ b/python-examples/computer-use/hooks/setup_context.py
@@ -6,7 +6,7 @@ from stagehand import Stagehand
 async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
     if api_name == "api/gemini-computer-use":
         stagehand = Stagehand(
-            env="LOCAL", local_browser_launch_options=dict(cdp_url=cdp_url)
+            env="LOCAL", local_browser_launch_options=dict(cdp_url=cdp_url, downloadPath="./tmp")
         )
         await stagehand.init()
         attempt_store.set("stagehand", stagehand)

--- a/python-examples/e-commerce-auth-scrapingcourse/auth-sessions-instances/test-auth-session/metadata.json
+++ b/python-examples/e-commerce-auth-scrapingcourse/auth-sessions-instances/test-auth-session/metadata.json
@@ -1,1 +1,5 @@
-{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{}}
+{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{
+    "username": "admin@example.com",
+    "password": "password"
+  }
+  }

--- a/python-examples/hybrid-automation/api/rpa/fill-form.py
+++ b/python-examples/hybrid-automation/api/rpa/fill-form.py
@@ -44,7 +44,7 @@ async def automation(
     stagehand = Stagehand(
         env="LOCAL",
         local_browser_launch_options=dict(
-            cdp_url=cdp_url, viewport=dict(width=1280, height=800)
+            cdp_url=cdp_url, viewport=dict(width=1280, height=800), downloadPath="./tmp"
         ),
         model_api_key=api_key,
         model_client_options={

--- a/python-examples/quick-recipes/api/download-file.py
+++ b/python-examples/quick-recipes/api/download-file.py
@@ -26,4 +26,6 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     # Return the suggested filename for reference
     file_name = downloaded_file.suggested_filename
     print(f"Downloaded file: {file_name}")
-    return file_name
+    return {
+        "file_name": file_name,
+    }

--- a/python-examples/stagehand/api/get-books.py
+++ b/python-examples/stagehand/api/get-books.py
@@ -33,7 +33,8 @@ async def automation(page: Page, params: Params, **_kwargs):
     stagehand = Stagehand(
         env="LOCAL",
         local_browser_launch_options=dict(
-            cdp_url=cdp_url, viewport=dict(width=1280, height=800)
+            cdp_url=cdp_url, viewport=dict(width=1280, height=800), 
+            downloadPath="./tmp"
         ),
         model_api_key=api_key,
         model_client_options={

--- a/typescript-examples/auth-with-secret-otp/auth-sessions-instances/test-auth-session/metadata.json
+++ b/typescript-examples/auth-with-secret-otp/auth-sessions-instances/test-auth-session/metadata.json
@@ -1,1 +1,6 @@
-{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{}}
+{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{
+    "username": "demo@email.com",
+    "password": "DemoUser2024!",
+    "secret": "JBSWY3DPEHPK3PXP"
+  }
+  }

--- a/typescript-examples/browser-sdk-showcase/README.md
+++ b/typescript-examples/browser-sdk-showcase/README.md
@@ -203,8 +203,8 @@ yarn intuned deploy
 
 ### File Operations
 - **download-file**: Download files from URLs or user interactions
-- **upload-file-to-s3**: Upload files to S3 buckets
-- **save-file-to-s3**: Save content directly to S3
+- **upload-file-to-s3**: Upload files to S3 (uses Intuned's managed bucket via gateway by default, or your own S3 with credentials)
+- **save-file-to-s3**: Save content directly to S3 (uses Intuned's managed bucket via gateway by default, or your own S3 with credentials)
 
 ### Utilities
 - **process-date**: Parse various date formats into standardized format

--- a/typescript-examples/browser-sdk-showcase/api/ai/extract-structured-data.ts
+++ b/typescript-examples/browser-sdk-showcase/api/ai/extract-structured-data.ts
@@ -40,6 +40,12 @@ export default async function handler(
 
   console.log(`Found product: ${product.name} - ${product.price}`);
 
-  return "Success";
+  return {
+    name: product.name,
+    price: product.price,
+    description: product.description,
+    in_stock: product.in_stock,
+    rating: product.rating,
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/click-until-exhausted.ts
+++ b/typescript-examples/browser-sdk-showcase/api/click-until-exhausted.ts
@@ -23,6 +23,9 @@ export default async function handler(
   });
 
   // Will keep clicking the button until the button disappears or is disabled or the max_clicks is reached.
-  return "Success";
+  const elements = await page.locator("main main slot slot div").count();
+  return {
+    number_of_elements: elements,
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/extract-markdown.ts
+++ b/typescript-examples/browser-sdk-showcase/api/extract-markdown.ts
@@ -18,6 +18,10 @@ export default async function handler(
   
   console.log("Markdown content of the header:");
   console.log(markdown);
-  return markdown;
+  return {
+    markdown,
+    source: "h1 header",
+    url: page.url(),
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/go-to-url.ts
+++ b/typescript-examples/browser-sdk-showcase/api/go-to-url.ts
@@ -28,6 +28,12 @@ export default async function handler(
   });
 
   // Start your automation here, the page is already loaded and ready to use.
-  return "Success";
+  const title = await page.title();
+  const url = page.url();
+
+  return {
+    title,
+    url,
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/resolve-url.ts
+++ b/typescript-examples/browser-sdk-showcase/api/resolve-url.ts
@@ -12,30 +12,34 @@ export default async function handler(
   context: BrowserContext
 ) {
   // Resolve a relative URL to an absolute URL
-  let absoluteUrl = await resolveUrl({
+  const urlWithBase = await resolveUrl({
     url: "/api/users",
     baseUrl: "https://example.com",
   });
   console.log("Result of resolving relative URL to absolute URL:");
-  console.log(absoluteUrl);
+  console.log(urlWithBase);
 
   // Resolve relative URL from the current page
   await page.goto("https://intunedhq.com");
-  absoluteUrl = await resolveUrl({
+  const urlFromPage = await resolveUrl({
     url: "/blog/intuned-act-3",
     page,
   });
   console.log("Result of resolving relative URL from the current page:");
-  console.log(absoluteUrl);
+  console.log(urlFromPage);
 
   // Resolve relative URL from an anchor tag
   await page.goto("https://intunedhq.com");
-  absoluteUrl = await resolveUrl({
+  const urlFromAnchor = await resolveUrl({
     url: page.locator("a:has-text('Schedule a demo')"),
   });
   console.log("Result of resolving relative URL from an anchor tag:");
-  console.log(absoluteUrl);
+  console.log(urlFromAnchor);
 
-  return "Success";
+  return {
+    url_with_base: urlWithBase,
+    url_from_page: urlFromPage,
+    url_from_anchor: urlFromAnchor,
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/sanitize-html.ts
+++ b/typescript-examples/browser-sdk-showcase/api/sanitize-html.ts
@@ -20,6 +20,8 @@ export default async function handler(
   const sanitizedHtml = sanitizeHtml({ html, removeStyles, maxAttributeLength });
   console.log("Sanitized HTML:");
   console.log(sanitizedHtml);
-  return sanitizedHtml;
+  return {
+    sanitized_html: sanitizedHtml,
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/save-file-to-s3.ts
+++ b/typescript-examples/browser-sdk-showcase/api/save-file-to-s3.ts
@@ -21,6 +21,10 @@ export default async function handler(
 
   const signedUrl = await uploadedFile.getSignedUrl();
   console.log(`Signed URL: ${signedUrl}`);
-  return signedUrl;
+  return {
+    file_name: uploadedFile.fileName,
+    signed_url: signedUrl,
+    message: "File uploaded successfully to S3"
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/scroll-to-load-content.ts
+++ b/typescript-examples/browser-sdk-showcase/api/scroll-to-load-content.ts
@@ -28,6 +28,9 @@ export default async function handler(
   });
 
   // Will keep scrolling until the page has loaded all content or the max_scrolls is reached.
-  return "Success";
+  const elements = await page.locator("main slot slot slot div").count();
+  return {
+    number_of_elements: elements,
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/upload-file-to-s3.ts
+++ b/typescript-examples/browser-sdk-showcase/api/upload-file-to-s3.ts
@@ -24,9 +24,12 @@ export default async function handler(
   });
 
   const signedUrl = await uploadedFile.getSignedUrl();
-  console.log("Signed URL:");
-  console.log(signedUrl);
+  console.log("Signed URL:", signedUrl);
 
-  return signedUrl;
+  return {
+    file_name: uploadedFile.fileName,
+    signed_url: signedUrl,
+    message: "File uploaded successfully to S3"
+  };
 }
 

--- a/typescript-examples/browser-sdk-showcase/api/validate-data-using-schema.ts
+++ b/typescript-examples/browser-sdk-showcase/api/validate-data-using-schema.ts
@@ -13,13 +13,13 @@ export default async function handler(
 ) {
   const uploadData = {
     file: {
-      file_name: "documents/report.pdf",
+      fileName: "documents/report.pdf",
       bucket: "my-bucket",
       region: "us-east-1",
       key: "documents/report.pdf",
       endpoint: null,
-      suggested_file_name: "Monthly Report.pdf",
-      file_type: "document",
+      suggestedFileName: "Monthly Report.pdf",
+      fileType: "document",
     },
     name: "Test File Upload",
   };
@@ -36,6 +36,10 @@ export default async function handler(
   validateDataUsingSchema({ data: uploadData, schema: uploadSchema });
   // Validation passes with Attachment type, it also validates Pydantic Attachment type.
   console.log("Validation passed");
-  return "Validation passed";
+  return {
+    status: "valid",
+    message: "Data validation passed successfully",
+    validated_data: uploadData,
+  };
 }
 

--- a/typescript-examples/captcha-solving-auth-example/auth-sessions-instances/test-auth-session/metadata.json
+++ b/typescript-examples/captcha-solving-auth-example/auth-sessions-instances/test-auth-session/metadata.json
@@ -1,1 +1,4 @@
-{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{}}
+{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{
+    "username": "demo@email.com",
+    "password": "password"
+  }}

--- a/typescript-examples/computer-use/api/gemini-computer-use.ts
+++ b/typescript-examples/computer-use/api/gemini-computer-use.ts
@@ -45,6 +45,7 @@ export default async function handler(
     localBrowserLaunchOptions: {
       cdpUrl: webSocketUrl,
       viewport: { width: 1280, height: 800 },
+      downloadsPath: "./tmp",
     },
     logger: console.log,
   });

--- a/typescript-examples/computer-use/api/stagehand.ts
+++ b/typescript-examples/computer-use/api/stagehand.ts
@@ -48,6 +48,7 @@ export default async function handler(
     localBrowserLaunchOptions: {
       cdpUrl: webSocketUrl,
       viewport: { width: 1280, height: 800 },
+      downloadsPath: "./tmp",
     },
     llmClient,
     logger: console.log,

--- a/typescript-examples/e-commerce-auth-scrapingcourse/auth-sessions-instances/test-auth-session/metadata.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/auth-sessions-instances/test-auth-session/metadata.json
@@ -1,1 +1,5 @@
-{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{}}
+{"createdAt":"2025-01-01T00:00:00.000Z","updatedAt":"2025-01-01T00:00:00.000Z","authSessionId":"test-auth-session","authSessionType":"API","authSessionInput":{
+    "username": "admin@example.com",
+    "password": "password"
+  }
+  }

--- a/typescript-examples/hybrid-automation/README.md
+++ b/typescript-examples/hybrid-automation/README.md
@@ -99,7 +99,7 @@ npx intuned run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
 
 ### Deploy project
 ```bash
-npx intuned deploy
+yarn intuned deploy
 ```
 
 <!-- IDE-IGNORE-END -->

--- a/typescript-examples/hybrid-automation/api/rpa/fill-form.ts
+++ b/typescript-examples/hybrid-automation/api/rpa/fill-form.ts
@@ -68,6 +68,7 @@ export default async function handler(
     localBrowserLaunchOptions: {
       cdpUrl: webSocketUrl,
       viewport: { width: 1280, height: 800 },
+      downloadsPath: "./tmp",
     },
     llmClient,
   });

--- a/typescript-examples/quick-recipes/api/download-file.ts
+++ b/typescript-examples/quick-recipes/api/download-file.ts
@@ -27,5 +27,7 @@ export default async function handler(
   // Return the suggested filename for reference
   const fileName = downloadedFile.suggestedFilename();
   console.log(`Downloaded file: ${fileName}`);
-  return fileName;
+  return {
+    file_name: fileName,
+  };
 }

--- a/typescript-examples/stagehand/api/get-books.ts
+++ b/typescript-examples/stagehand/api/get-books.ts
@@ -60,6 +60,7 @@ export default async function handler(
     localBrowserLaunchOptions: {
       cdpUrl: webSocketUrl,
       viewport: { width: 1280, height: 800 },
+      downloadsPath: "./tmp",
     },
     llmClient,
     logger: console.log,


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

