### PR TITLE
Update jsdom dependency in jsdom-example package.json from version 27.3.0 to 26.1.0 to match with the node version on the platform

### DIFF
--- a/typescript-examples/jsdom-example/package.json
+++ b/typescript-examples/jsdom-example/package.json
@@ -13,7 +13,7 @@
     "@intuned/browser": "0.1.8",
     "@intuned/runtime": "1.3.16",
     "@types/node": "^20.10.3",
-    "jsdom": "^27.3.0",
+    "jsdom": "^26.1.0",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"
   }


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [x] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [x] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [x] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [x] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [x] Main README and language-specific README updated if adding/modifying examples

