### PR TITLE
Add links to Intuned llm.txt in various Python and TypeScript example READMEs

### DIFF
--- a/python-examples/auth-with-email-otp/README.md
+++ b/python-examples/auth-with-email-otp/README.md
@@ -129,3 +129,4 @@ This project requires the following environment variables:
 - [Auth Sessions Documentation](https://docs.intunedhq.com/docs/02-features/auth-sessions)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Intuned In-Depth](https://docs.intunedhq.com/docs/01-learn/deep-dives/intuned-indepth)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/auth-with-secret-otp/README.md
+++ b/python-examples/auth-with-secret-otp/README.md
@@ -105,3 +105,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Auth Sessions Documentation](https://docs.intunedhq.com/docs/02-features/auth-sessions)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [OTP Authentication Guide](https://docs.intunedhq.com/docs/01-learn/deep-dives/intuned-indepth)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/browser-sdk-showcase/README.md
+++ b/python-examples/browser-sdk-showcase/README.md
@@ -191,3 +191,4 @@ uv run intuned deploy
 For detailed documentation on each helper function, visit:
 - [Intuned Browser SDK - Python](https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/)
 - [Browser SDK Overview](https://docs.intunedhq.com/automation-sdks/overview)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/browser-use/README.md
+++ b/python-examples/browser-use/README.md
@@ -116,3 +116,4 @@ uv run intuned deploy
 - **Intuned Runtime SDK**: https://docs.intunedhq.com/docs/05-references/runtime-sdk-python/overview
 - **Setup Hooks**: https://docs.intunedhq.com/docs/01-learn/recipes/setup-hooks
 - **Intuned Concepts**: https://docs.intunedhq.com/docs/00-getting-started/introduction
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/bs4/README.md
+++ b/python-examples/bs4/README.md
@@ -136,3 +136,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/captcha-solving-auth/README.md
+++ b/python-examples/captcha-solving-auth/README.md
@@ -133,3 +133,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/captcha-solving-basic/README.md
+++ b/python-examples/captcha-solving-basic/README.md
@@ -121,4 +121,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
-  
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/cdp-connection/README.md
+++ b/python-examples/cdp-connection/README.md
@@ -54,3 +54,7 @@ The project structure is as follows:
 │           └── default.json  # Default parameters (URL to navigate to)
 └── Intuned.jsonc             # Intuned project configuration file
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/computer-use/README.md
+++ b/python-examples/computer-use/README.md
@@ -156,6 +156,7 @@ uv run intuned deploy
 - **OpenAI Operator API**: https://platform.openai.com/docs/
 - **Stagehand Documentation**: https://docs.stagehand.dev/
 - **Browser Use Documentation**: https://github.com/browser-use/browser-use
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)
 
 ## Acknowledgments
 

--- a/python-examples/crawl4ai/README.md
+++ b/python-examples/crawl4ai/README.md
@@ -38,6 +38,7 @@ Open this project in Intuned by clicking the button below.
 
 - [crawl4ai Documentation](https://docs.crawl4ai.com/)
 - [Intuned Documentation](https://docs.intunedhq.com/)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)
 
 
 ### `intuned-browser`: Intuned Browser SDK

--- a/python-examples/e-commerce-auth-scrapingcourse/README.md
+++ b/python-examples/e-commerce-auth-scrapingcourse/README.md
@@ -194,3 +194,7 @@ This project uses the Intuned browser SDK for enhanced reliability:
 - **`extend_payload`**: Trigger additional API calls dynamically (used to trigger `details` API for each product)
 
 For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/e-commerce-nested/README.md
+++ b/python-examples/e-commerce-nested/README.md
@@ -95,4 +95,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Web Scraping Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/)
 - [extend_payload Helper](https://docs.intunedhq.com/docs/05-references/runtime-sdk-python/extend-payload)
-
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/e-commerce-scrapingcourse/README.md
+++ b/python-examples/e-commerce-scrapingcourse/README.md
@@ -92,3 +92,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Web Scraping Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/)
 - [extend_payload Helper](https://docs.intunedhq.com/docs/05-references/runtime-sdk-python/extend-payload)
 - [save_file_to_s3 Helper](https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/helpers/functions/save_file_to_s3)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/e-commerce-shopify/README.md
+++ b/python-examples/e-commerce-shopify/README.md
@@ -88,4 +88,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Shopify API Documentation](https://shopify.dev/docs/api)
 - [Web Scraping Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/)
-
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/ehr-integration/README.md
+++ b/python-examples/ehr-integration/README.md
@@ -118,3 +118,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Auth Sessions Guide](https://docs.intunedhq.com/docs/02-features/auth-sessions)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [OpenIMIS Documentation](https://openimis.org/)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/firecrawl/README.md
+++ b/python-examples/firecrawl/README.md
@@ -220,6 +220,7 @@ See [Intuned Documentation](https://docs.intunedhq.com) for deployment details.
 - **Firecrawl API Reference:** [docs.firecrawl.dev](https://docs.firecrawl.dev/api-reference/introduction)
 - **crawl4ai Documentation:** [docs.crawl4ai.com](https://docs.crawl4ai.com)
 - **Intuned Platform:** [docs.intunedhq.com](https://docs.intunedhq.com)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)
 
 ---
 

--- a/python-examples/hybrid-automation/README.md
+++ b/python-examples/hybrid-automation/README.md
@@ -154,3 +154,4 @@ uv run intuned deploy
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Extract Structured Data](https://docs.intunedhq.com/automation-sdks/intuned-sdk/python/ai/functions/extract_structured_data)
 - [Stagehand act/extract/observe](https://docs.stagehand.dev/v2/basics/act)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/native-crawler/README.md
+++ b/python-examples/native-crawler/README.md
@@ -183,3 +183,4 @@ The `persistent_store` uses these key patterns:
 - [Intuned Jobs Documentation](https://docs.intunedhq.com/docs-old/platform/consume/jobs)
 - [Nested Scheduling / extend_payload](https://docs.intunedhq.com/docs-old/platform/consume/nested-scheduling)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/network-interception/README.md
+++ b/python-examples/network-interception/README.md
@@ -156,3 +156,7 @@ These patterns are useful when you need to interact with APIs that require CSRF 
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/playwright-basics/README.md
+++ b/python-examples/playwright-basics/README.md
@@ -113,3 +113,4 @@ uv run intuned deploy
 
 - [Playwright deep dive](https://docs.intunedhq.com/docs/01-learn/deep-dives/playwright)
 - [Intuned SDK](https://docs.intunedhq.com/automation-sdks/overview)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/quick-recipes/README.md
+++ b/python-examples/quick-recipes/README.md
@@ -121,3 +121,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Handle load more buttons Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/load-more-button)
 - [Scrape without writing selectors Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/ai-scraper)
 - [Handle long-running automations with timeouts Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/long-running-api)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/rpa-auth-example/README.md
+++ b/python-examples/rpa-auth-example/README.md
@@ -126,3 +126,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Auth Sessions Documentation](https://docs.intunedhq.com/docs/02-features/auth-sessions)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [RPA with Intuned](https://docs.intunedhq.com/docs/01-learn/deep-dives/intuned-indepth)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/rpa-example/README.md
+++ b/python-examples/rpa-example/README.md
@@ -88,3 +88,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - **Intuned Concepts**: https://docs.intunedhq.com/docs/00-getting-started/introduction
 - **Intuned Browser SDK**: https://docs.intunedhq.com/automation-sdks/overview
 - **CLI Documentation**: https://docs.intunedhq.com/docs/05-references/cli
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/rpa-forms-example/README.md
+++ b/python-examples/rpa-forms-example/README.md
@@ -141,3 +141,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/scrapy/README.md
+++ b/python-examples/scrapy/README.md
@@ -183,4 +183,7 @@ To adapt this example for your own scraping needs:
   "region": "us"
 }
 ```
-  
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/setup-hooks/README.md
+++ b/python-examples/setup-hooks/README.md
@@ -54,3 +54,7 @@ The project structure is as follows:
 │           └── default.json  # Default parameters
 └── Intuned.jsonc             # Intuned project configuration file
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/stagehand/README.md
+++ b/python-examples/stagehand/README.md
@@ -95,3 +95,4 @@ uv run intuned deploy
 - **Stagehand Documentation**: https://docs.stagehand.dev/
 - **Intuned Runtime SDK**: https://docs.intunedhq.com/docs/05-references/runtime-sdk-python/overview
 - **Setup Hooks**: https://docs.intunedhq.com/docs/01-learn/recipes/setup-hooks
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/starter-auth/README.md
+++ b/python-examples/starter-auth/README.md
@@ -155,3 +155,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/python-examples/starter/README.md
+++ b/python-examples/starter/README.md
@@ -77,3 +77,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Getting Started Guide](https://docs.intunedhq.com/docs/00-getting-started/introduction)
 - [CLI Reference](https://docs.intunedhq.com/docs/05-references/cli)
 - [Intuned.jsonc Reference](https://docs.intunedhq.com/docs/05-references/intuned-json)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/auth-with-email-otp/README.md
+++ b/typescript-examples/auth-with-email-otp/README.md
@@ -144,3 +144,4 @@ This project requires the following environment variables:
 - [Auth Sessions Documentation](https://docs.intunedhq.com/docs/02-features/auth-sessions)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Intuned In-Depth](https://docs.intunedhq.com/docs/01-learn/deep-dives/intuned-indepth)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/auth-with-secret-otp/README.md
+++ b/typescript-examples/auth-with-secret-otp/README.md
@@ -176,3 +176,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/browser-sdk-showcase/README.md
+++ b/typescript-examples/browser-sdk-showcase/README.md
@@ -223,3 +223,4 @@ yarn intuned deploy
 For detailed documentation on each helper function, visit:
 - [Intuned Browser SDK - TypeScript](https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/)
 - [Browser SDK Overview](https://docs.intunedhq.com/automation-sdks/overview)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/captcha-solving-auth/README.md
+++ b/typescript-examples/captcha-solving-auth/README.md
@@ -150,3 +150,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/captcha-solving-basic/README.md
+++ b/typescript-examples/captcha-solving-basic/README.md
@@ -146,4 +146,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
-  
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/cdp-connection/README.md
+++ b/typescript-examples/cdp-connection/README.md
@@ -66,3 +66,7 @@ The project structure is as follows:
 │           └── default.json  # Default parameters (URL to navigate to)
 └── Intuned.jsonc             # Intuned project configuration file
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/computer-use/README.md
+++ b/typescript-examples/computer-use/README.md
@@ -204,6 +204,7 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - **Anthropic Computer Use**: https://docs.anthropic.com/en/docs/computer-use
 - **OpenAI Operator API**: https://platform.openai.com/docs/
 - **Stagehand Documentation**: https://docs.stagehand.dev/
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)
 
 ## Acknowledgments
 

--- a/typescript-examples/e-commerce-auth-scrapingcourse/README.md
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/README.md
@@ -227,3 +227,7 @@ This project uses the Intuned browser SDK for enhanced reliability:
 - **`extendPayload`**: Trigger additional API calls dynamically (used to trigger `details` API for each product)
 
 For more information, check out the [Intuned Browser SDK documentation](https://docs.intunedhq.com/automation-sdks/overview).
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/e-commerce-nested/README.md
+++ b/typescript-examples/e-commerce-nested/README.md
@@ -114,3 +114,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Web Scraping Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/)
 - [extendPayload Helper](https://docs.intunedhq.com/docs/05-references/runtime-sdk-typescript/extend-payload)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/e-commerce-scrapingcourse/README.md
+++ b/typescript-examples/e-commerce-scrapingcourse/README.md
@@ -109,3 +109,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Web Scraping Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/)
 - [extendPayload Helper](https://docs.intunedhq.com/docs/05-references/runtime-sdk-typescript/extend-timeout)
 - [saveFileToS3 Helper](https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/helpers/functions/saveFileToS3)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/e-commerce-shopify/README.md
+++ b/typescript-examples/e-commerce-shopify/README.md
@@ -106,3 +106,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Shopify API Documentation](https://shopify.dev/docs/api)
 - [Web Scraping Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/ehr-integration/README.md
+++ b/typescript-examples/ehr-integration/README.md
@@ -149,3 +149,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Auth Sessions Guide](https://docs.intunedhq.com/docs/02-features/auth-sessions)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [OpenIMIS Documentation](https://openimis.org/)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/hybrid-automation/README.md
+++ b/typescript-examples/hybrid-automation/README.md
@@ -155,3 +155,4 @@ yarn intuned deploy
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [Extract Structured Data](https://docs.intunedhq.com/automation-sdks/intuned-sdk/typescript/ai/functions/extractStructuredData)
 - [Stagehand act/extract/observe](https://docs.stagehand.dev/v2/basics/act)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/jsdom/README.md
+++ b/typescript-examples/jsdom/README.md
@@ -158,3 +158,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/native-crawler/README.md
+++ b/typescript-examples/native-crawler/README.md
@@ -197,3 +197,4 @@ The `persistentStore` uses these key patterns:
 - [Intuned Jobs Documentation](https://docs.intunedhq.com/docs-old/platform/consume/jobs)
 - [Nested Scheduling / extendPayload](https://docs.intunedhq.com/docs-old/platform/consume/nested-scheduling)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/network-interception/README.md
+++ b/typescript-examples/network-interception/README.md
@@ -174,3 +174,7 @@ These patterns are useful when you need to interact with APIs that require CSRF 
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/playwright-basics/README.md
+++ b/typescript-examples/playwright-basics/README.md
@@ -114,3 +114,4 @@ yarn intuned deploy
 
 - [Playwright deep dive](https://docs.intunedhq.com/docs/01-learn/deep-dives/playwright)
 - [Intuned SDK](https://docs.intunedhq.com/automation-sdks/overview)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/quick-recipes/README.md
+++ b/typescript-examples/quick-recipes/README.md
@@ -146,3 +146,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Handle load more buttons Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/load-more-button)
 - [Scrape without writing selectors Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/ai-scraper)
 - [Handle long-running automations with timeouts Recipe](https://docs.intunedhq.com/docs/01-learn/recipes/long-running-api)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/rpa-auth-example/README.md
+++ b/typescript-examples/rpa-auth-example/README.md
@@ -177,3 +177,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Auth Sessions Documentation](https://docs.intunedhq.com/docs/02-features/auth-sessions)
 - [Intuned Browser SDK](https://docs.intunedhq.com/automation-sdks/overview)
 - [RPA with Intuned](https://docs.intunedhq.com/docs/01-learn/deep-dives/intuned-indepth)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/rpa-example/README.md
+++ b/typescript-examples/rpa-example/README.md
@@ -109,3 +109,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - **Intuned Concepts**: https://docs.intunedhq.com/docs/00-getting-started/introduction
 - **Intuned Browser SDK**: https://docs.intunedhq.com/automation-sdks/overview
 - **CLI Documentation**: https://docs.intunedhq.com/docs/05-references/cli
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/rpa-forms-example/README.md
+++ b/typescript-examples/rpa-forms-example/README.md
@@ -159,3 +159,6 @@ The project structure is as follows:
 }
 ```
 
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/setup-hooks/README.md
+++ b/typescript-examples/setup-hooks/README.md
@@ -66,3 +66,7 @@ The project structure is as follows:
 │           └── default.json  # Default parameters
 └── Intuned.jsonc             # Intuned project configuration file
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/stagehand/README.md
+++ b/typescript-examples/stagehand/README.md
@@ -110,3 +110,4 @@ yarn intuned deploy
 - **Stagehand Documentation**: https://docs.stagehand.dev/
 - **Intuned Runtime SDK**: https://docs.intunedhq.com/automation-sdks/overview
 - **Setup Hooks**: https://docs.intunedhq.com/docs/01-learn/recipes/setup-hooks
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/starter-auth/README.md
+++ b/typescript-examples/starter-auth/README.md
@@ -180,3 +180,7 @@ The project structure is as follows:
   "region": "us"
 }
 ```
+
+## Learn More
+
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)

--- a/typescript-examples/starter/README.md
+++ b/typescript-examples/starter/README.md
@@ -94,3 +94,4 @@ This project uses Intuned browser SDK. For more information, check out the [Intu
 - [Getting Started Guide](https://docs.intunedhq.com/docs/00-getting-started/introduction)
 - [CLI Reference](https://docs.intunedhq.com/docs/05-references/cli)
 - [Intuned.jsonc Reference](https://docs.intunedhq.com/docs/05-references/intuned-json)
+- [Intuned llm.txt](https://docs.intunedhq.com/llms.txt)


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

