### PR TITLE
Bug 254: Remove While true from templates

### DIFF
--- a/python-examples/computer-use/api/anthropic-computer-use.py
+++ b/python-examples/computer-use/api/anthropic-computer-use.py
@@ -7,6 +7,7 @@ from playwright.async_api import Page
 
 class Params(TypedDict):
     query: str  # The task you want the AI to perform
+    max_iterations: int | None = None
 
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
@@ -24,13 +25,16 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
 
     final_messages = await sampling_loop(
         model=model,
-        messages=[{
-            "role": "user",
-            "content": params["query"],
-        }],
+        messages=[
+            {
+                "role": "user",
+                "content": params["query"],
+            }
+        ],
         api_key=api_key,
         base_url=base_url,
         thinking_budget=1024,
+        max_iterations=params.get("max_iterations", 50),
         playwright_page=page,
     )
 
@@ -47,7 +51,8 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
         result = last_message["content"]  # type: ignore[assignment]
     else:
         result = "".join(
-            block["text"] for block in last_message["content"]  # type: ignore[index]
+            block["text"]
+            for block in last_message["content"]  # type: ignore[index]
             if isinstance(block, dict) and block.get("type") == "text"
         )
 

--- a/python-examples/e-commerce-scrapingcourse/api/list.py
+++ b/python-examples/e-commerce-scrapingcourse/api/list.py
@@ -104,7 +104,8 @@ async def automation(page: Page, params: Params, **_kwargs) -> list[Product]:
     current_page = 1
 
     # Loop through all pages until there are no more pages or limit is reached
-    while True:
+    while current_page < page_limit:
+        current_page += 1
         print(f"Scraping page {current_page}...")
 
         # Extract all products from the current page
@@ -112,11 +113,6 @@ async def automation(page: Page, params: Params, **_kwargs) -> list[Product]:
 
         # Add the products from this page to our complete list
         all_products.extend(products)
-
-        # Check if we've reached the page limit
-        if current_page >= page_limit:
-            print(f"Reached page limit of {page_limit} pages")
-            break
 
         # Check if there's a next page available
         has_next = await has_next_page(page)

--- a/python-examples/e-commerce-scrapingcourse/utils/types_and_schemas.py
+++ b/python-examples/e-commerce-scrapingcourse/utils/types_and_schemas.py
@@ -1,4 +1,3 @@
-
 from intuned_browser import Attachment
 from pydantic import BaseModel, HttpUrl, field_validator
 

--- a/python-examples/ehr-integration/api/claims.py
+++ b/python-examples/ehr-integration/api/claims.py
@@ -5,7 +5,7 @@ from playwright.async_api import Page
 
 
 class Params(TypedDict):
-    pass
+    max_pages: int
 
 
 async def extract_claims_data(page: Page) -> list[dict[str, str]]:
@@ -42,7 +42,10 @@ async def extract_claims_data(page: Page) -> list[dict[str, str]]:
 async def automation(page: Page, params: Params | None = None, **_kwargs):
     all_results = []
     await go_to_url(page, "https://demo.openimis.org/front/claim/healthFacilities")
-    while True:
+    max_pages = params.max_pages if params else 10
+    current_page = 0
+    while current_page < max_pages:
+        current_page += 1
         # Extract data from current page
         result = await extract_claims_data(page)
         all_results.extend(result)

--- a/python-examples/ehr-integration/api/families.py
+++ b/python-examples/ehr-integration/api/families.py
@@ -5,7 +5,7 @@ from playwright.async_api import Page
 
 
 class Params(TypedDict):
-    pass
+    max_pages: int
 
 
 async def extract_families_data(page: Page) -> list[dict[str, str]]:
@@ -41,7 +41,10 @@ async def extract_families_data(page: Page) -> list[dict[str, str]]:
 async def automation(page: Page, params: Params | None = None, **_kwargs):
     all_results = []
     await go_to_url(page, "https://demo.openimis.org/front/insuree/families")
-    while True:
+    max_pages = params.max_pages if params else 10
+    current_page = 0
+    while current_page < max_pages:
+        current_page += 1
         # Extract data from current page
         result = await extract_families_data(page)
         all_results.extend(result)

--- a/python-examples/ehr-integration/api/insurees.py
+++ b/python-examples/ehr-integration/api/insurees.py
@@ -5,7 +5,7 @@ from playwright.async_api import Page
 
 
 class Params(TypedDict):
-    pass
+    max_pages: int
 
 
 async def extract_insurees_data(page: Page) -> list[dict[str, str]]:
@@ -38,7 +38,10 @@ async def extract_insurees_data(page: Page) -> list[dict[str, str]]:
 async def automation(page: Page, params: Params | None = None, **_kwargs):
     all_results = []
     await go_to_url(page, "https://demo.openimis.org/front/insuree/insurees")
-    while True:
+    max_pages = params.max_pages if params else 10
+    current_page = 0
+    while current_page < max_pages:
+        current_page += 1
         # Extract data from current page
         result = await extract_insurees_data(page)
         all_results.extend(result)


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [x] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [x] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [x] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [x] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [x] Main README and language-specific README updated if adding/modifying examples

