### PR TITLE
release typescript runtime 1.3.21

### DIFF
--- a/typescript-examples/auth-with-email-otp/package.json
+++ b/typescript-examples/auth-with-email-otp/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "resend": "^6.6.0",

--- a/typescript-examples/auth-with-secret-otp/package.json
+++ b/typescript-examples/auth-with-secret-otp/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "otplib": "^12.0.1",
     "playwright": "~1.56.0",

--- a/typescript-examples/browser-sdk-showcase/package.json
+++ b/typescript-examples/browser-sdk-showcase/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/captcha-solving-auth/package.json
+++ b/typescript-examples/captcha-solving-auth/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/captcha-solving-basic/package.json
+++ b/typescript-examples/captcha-solving-basic/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/cdp-connection/package.json
+++ b/typescript-examples/cdp-connection/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/computer-use/package.json
+++ b/typescript-examples/computer-use/package.json
@@ -19,7 +19,7 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@browserbasehq/stagehand": "3.0.6",
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "luxon": "^3.7.2",
     "openai": "^6.10.0",

--- a/typescript-examples/e-commerce-auth-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/e-commerce-nested/package.json
+++ b/typescript-examples/e-commerce-nested/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/e-commerce-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-scrapingcourse/package.json
@@ -10,7 +10,7 @@
     "license": "ISC",
     "dependencies": {
         "@intuned/browser": "0.1.10",
-        "@intuned/runtime": "1.3.20",
+        "@intuned/runtime": "1.3.21",
         "@types/node": "^20.10.3",
         "playwright": "~1.56.0",
         "zod": "^3.22.4"

--- a/typescript-examples/e-commerce-shopify/package.json
+++ b/typescript-examples/e-commerce-shopify/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/ehr-integration/package.json
+++ b/typescript-examples/ehr-integration/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/hybrid-automation/package.json
+++ b/typescript-examples/hybrid-automation/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@browserbasehq/stagehand": "3.0.6",
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "3.25.67"

--- a/typescript-examples/jsdom/package.json
+++ b/typescript-examples/jsdom/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "jsdom": "^26.1.0",
     "playwright": "~1.56.0",

--- a/typescript-examples/native-crawler/package.json
+++ b/typescript-examples/native-crawler/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   },

--- a/typescript-examples/network-interception/package.json
+++ b/typescript-examples/network-interception/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/playwright-basics/package.json
+++ b/typescript-examples/playwright-basics/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/quick-recipes/package.json
+++ b/typescript-examples/quick-recipes/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/rpa-auth-example/package.json
+++ b/typescript-examples/rpa-auth-example/package.json
@@ -16,7 +16,7 @@
     "license": "ISC",
     "dependencies": {
         "@intuned/browser": "0.1.10",
-        "@intuned/runtime": "1.3.20",
+        "@intuned/runtime": "1.3.21",
         "@types/node": "^20.10.3",
         "playwright": "~1.56.0",
         "zod": "^3.22.4"

--- a/typescript-examples/rpa-example/package.json
+++ b/typescript-examples/rpa-example/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/rpa-forms-example/package.json
+++ b/typescript-examples/rpa-forms-example/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@browserbasehq/stagehand": "^3.0.6",
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "3.25.67"

--- a/typescript-examples/setup-hooks/package.json
+++ b/typescript-examples/setup-hooks/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/stagehand/package.json
+++ b/typescript-examples/stagehand/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@browserbasehq/stagehand": "3.0.6",
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "3.25.67"

--- a/typescript-examples/starter-auth/package.json
+++ b/typescript-examples/starter-auth/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/starter/package.json
+++ b/typescript-examples/starter/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.10",
-    "@intuned/runtime": "1.3.20",
+    "@intuned/runtime": "1.3.21",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

