### PR TITLE
remove set-viewport from python examples

### DIFF
--- a/python-examples/e-commerce-nested/api/details.py
+++ b/python-examples/e-commerce-nested/api/details.py
@@ -133,7 +133,6 @@ async def automation(
         "details_url": "https://www.example.com/product/item-1"
     }
     """
-    await page.set_viewport_size({"width": 1280, "height": 800})
     params = EcommereceDetailsParams(**params)
     if not params.details_url:
         raise ValueError("Params with details_url are required for this automation")

--- a/python-examples/e-commerce-nested/api/list.py
+++ b/python-examples/e-commerce-nested/api/list.py
@@ -103,7 +103,6 @@ async def automation(
     then extracts product metadata (name, price, details_url) and uses
     extend_payload to trigger individual scrapes for each product's details.
     """
-    await page.set_viewport_size({"width": 1280, "height": 800})
     params = EcommereceListParams(**params)
     if not params.category_url:
         raise ValueError("category_url is required in params")

--- a/python-examples/hybrid-automation/api/scraper/details.py
+++ b/python-examples/hybrid-automation/api/scraper/details.py
@@ -246,7 +246,6 @@ async def automation(
         "details_url": "https://www.example.com/product/item-1"
     }
     """
-    await page.set_viewport_size({"width": 1280, "height": 800})
     params = EcommereceDetailsParams(**params)
     if not params.details_url:
         raise ValueError("Params with details_url are required for this automation")

--- a/python-examples/hybrid-automation/api/scraper/list.py
+++ b/python-examples/hybrid-automation/api/scraper/list.py
@@ -114,7 +114,6 @@ async def automation(
     then extracts product metadata (name, price, details_url) and uses
     extend_payload to trigger individual scrapes for each product's details.
     """
-    await page.set_viewport_size({"width": 1280, "height": 800})
     params = EcommereceListParams(**params)
     if not params.category_url:
         raise ValueError("category_url is required in params")

--- a/python-examples/rpa-auth-example/api/book-consultations.py
+++ b/python-examples/rpa-auth-example/api/book-consultations.py
@@ -49,11 +49,7 @@ async def automation(
     context: BrowserContext | None = None,
     **_kwargs,
 ) -> dict:
-    # Set the browser viewport size to 1080x720 pixels
-    # This ensures consistent rendering across different devices and screen sizes
-    # Some websites may display different layouts or elements based on viewport size
-    await page.set_viewport_size({"width": 1080, "height": 720})
-
+   
     # Step 1: Validate input parameters using schema
     # This ensures all required fields are present and properly formatted
     if params is None:

--- a/python-examples/rpa-example/api/book-consultations.py
+++ b/python-examples/rpa-example/api/book-consultations.py
@@ -49,10 +49,6 @@ async def automation(
     context: BrowserContext | None = None,
     **_kwargs,
 ) -> dict:
-    # Set the browser viewport size to 1080x720 pixels
-    # This ensures consistent rendering across different devices and screen sizes
-    # Some websites may display different layouts or elements based on viewport size
-    await page.set_viewport_size({"width": 1080, "height": 720})
 
     # Step 1: Validate input parameters using schema
     # This ensures all required fields are present and properly formatted

--- a/python-examples/rpa-forms-example/api/insurance-form-filler.py
+++ b/python-examples/rpa-forms-example/api/insurance-form-filler.py
@@ -40,7 +40,6 @@ async def automation(page: Page, params: ListParameters, *args: ..., **kwargs: .
     session_id = session.data.session_id
     print(f"✅ Session started: {session_id}")
     print("\nInitialized 🤘 Stagehand")
-    await page.set_viewport_size({"width": 1280, "height": 800})
 
     async def perform_action(page: Page, instruction: str) -> None:
         for _ in range(3):

--- a/python-examples/stagehand/api/get-books.py
+++ b/python-examples/stagehand/api/get-books.py
@@ -57,8 +57,6 @@ async def automation(page: Page, params: Params, **_kwargs):
     print(f"✅ Session started: {session_id}")
     print("\nInitialized 🤘 Stagehand")
 
-    await page.set_viewport_size({"width": 1280, "height": 800})
-
     category = params.get("category")
     all_books: list[BookDetails] = []
 

--- a/python-examples/starter-auth/api/sample.py
+++ b/python-examples/starter-auth/api/sample.py
@@ -9,8 +9,6 @@ class Params(TypedDict):
 
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
-    await page.set_viewport_size({"width": 1080, "height": 720})
-
     sandboxed_url = "https://sandbox.intuned.dev/consultations-auth/book"
 
     await go_to_url(page=page, url=sandboxed_url)


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

