### PR TITLE
remove set viewpport size in ts exmples

### DIFF
--- a/python-examples/e-commerce-nested/api/category.py
+++ b/python-examples/e-commerce-nested/api/category.py
@@ -69,7 +69,6 @@ async def automation(
     This function collects category metadata (name, url) from the main menu
     and then uses extend_payload to trigger individual scrapes for each category's products.
     """
-    await page.set_viewport_size({"width": 1280, "height": 800})
     params = EcommereceCategoryParams(**params)
     if not params.store_url:
         raise ValueError("store_url is required in params")

--- a/typescript-examples/e-commerce-nested/api/category.ts
+++ b/typescript-examples/e-commerce-nested/api/category.ts
@@ -74,7 +74,6 @@ async function handler(
   page: Page,
   context: BrowserContext
 ): Promise<{ categories: Category[] }> {
-  await page.setViewportSize({ width: 1280, height: 800 });
 
   if (!params || !params.store_url) {
     throw new Error("store_url is required in params");

--- a/typescript-examples/e-commerce-nested/api/details.ts
+++ b/typescript-examples/e-commerce-nested/api/details.ts
@@ -162,7 +162,7 @@ async function handler(
   page: Page,
   context: BrowserContext
 ): Promise<ProductDetails> {
-  await page.setViewportSize({ width: 1280, height: 800 });
+ 
 
   if (!params || !params.details_url) {
     throw new Error("Params with details_url are required for this automation");

--- a/typescript-examples/e-commerce-nested/api/list.ts
+++ b/typescript-examples/e-commerce-nested/api/list.ts
@@ -115,8 +115,6 @@ async function handler(
   page: Page,
   context: BrowserContext
 ): Promise<{ category: string; products: Product[] }> {
-  await page.setViewportSize({ width: 1280, height: 800 });
-
   if (!params || !params.category_url) {
     throw new Error("category_url is required in params");
   }

--- a/typescript-examples/hybrid-automation/api/scraper/details.ts
+++ b/typescript-examples/hybrid-automation/api/scraper/details.ts
@@ -196,7 +196,6 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ): Promise<ProductDetails> {
-  await page.setViewportSize({ width: 1280, height: 800 });
 
   const { name: paramName, details_url } = detailsParamsSchema.parse(params);
 

--- a/typescript-examples/hybrid-automation/api/scraper/list.ts
+++ b/typescript-examples/hybrid-automation/api/scraper/list.ts
@@ -90,7 +90,6 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  await page.setViewportSize({ width: 1280, height: 800 });
 
   const { category_name, category_url } = listParamsSchema.parse(params);
 

--- a/typescript-examples/rpa-auth-example/api/book-consultations.ts
+++ b/typescript-examples/rpa-auth-example/api/book-consultations.ts
@@ -60,14 +60,7 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  // Set the browser viewport size to 1080x720 pixels
-  // This ensures consistent rendering across different devices and screen sizes
-  // Some websites may display different layouts or elements based on viewport size
-  await page.setViewportSize({
-    width: 1080,
-    height: 720,
-  });
-
+ 
   // Step 1: Validate input parameters using schema
   // This ensures all required fields are present and properly formatted
   const validatedParams = bookConsultationSchema.parse(params);

--- a/typescript-examples/rpa-example/api/book-consultations.ts
+++ b/typescript-examples/rpa-example/api/book-consultations.ts
@@ -66,13 +66,6 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ): Promise<BookingResult> {
-  // Set the browser viewport size to 1080x720 pixels
-  // This ensures consistent rendering across different devices and screen sizes
-  // Some websites may display different layouts or elements based on viewport size
-  await page.setViewportSize({
-    width: 1080,
-    height: 720,
-  });
 
   // Step 1: Validate input parameters using schema
   // This ensures all required fields are present and properly formatted

--- a/typescript-examples/rpa-forms-example/api/insurance-form-filler.ts
+++ b/typescript-examples/rpa-forms-example/api/insurance-form-filler.ts
@@ -71,7 +71,6 @@ export default async function handler(
   await stagehand.init();
   console.log("\nInitialized 🤘 Stagehand");
   // Validate parameters
-  await page.setViewportSize({ width: 1280, height: 800 });
   const validatedParams = listParametersSchema.parse(params);
 
   const { metadata, applicant, address, vehicle } = validatedParams;

--- a/typescript-examples/starter-auth/api/sample.ts
+++ b/typescript-examples/starter-auth/api/sample.ts
@@ -12,11 +12,6 @@ export default async function handler(
   page: Page,
   context: BrowserContext
 ) {
-  await page.setViewportSize({
-    width: 1080,
-    height: 720,
-  });
-
   const sandboxedUrl = "https://sandbox.intuned.dev/consultations-auth/book";
 
   await goToUrl({


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

