### PR TITLE
Replace crawl4ai fork with upstream package

### DIFF
--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "playwright==1.56",
     "intuned-runtime==1.3.25",
     "intuned-browser==0.1.15",
-    "crawl4ai @ git+https://github.com/izzat5233/crawl4ai.git",
+    "crawl4ai",
 ]
 
 [tool.uv]

--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "playwright==1.56",
     "intuned-runtime==1.3.25",
     "intuned-browser==0.1.15",
-    "crawl4ai",
+    "crawl4ai==0.8.6",
 ]
 
 [tool.uv]

--- a/python-examples/firecrawl/pyproject.toml
+++ b/python-examples/firecrawl/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "playwright==1.56",
     "intuned-runtime==1.3.25",
     "intuned-browser==0.1.15",
-    "crawl4ai @ git+https://github.com/izzat5233/crawl4ai.git",
+    "crawl4ai",
     "pytz>=2024.1",
     "tavily-python>=0.5.0",
 ]

--- a/python-examples/firecrawl/pyproject.toml
+++ b/python-examples/firecrawl/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "playwright==1.56",
     "intuned-runtime==1.3.25",
     "intuned-browser==0.1.15",
-    "crawl4ai",
+    "crawl4ai==0.8.6",
     "pytz>=2024.1",
     "tavily-python>=0.5.0",
 ]


### PR DESCRIPTION
## Summary
- Switch `crawl4ai` dependency from forked repo (`izzat5233/crawl4ai`) to upstream PyPI package in both `crawl4ai` and `firecrawl` templates
- The fork's download error fix has no practical impact on either template — all 34 testable APIs pass identically with upstream

## Test plan
- [x] Tested all 9 crawl4ai template APIs (simple-crawl, multi-crawl, deep-crawl, css-based, statistical)
- [x] Tested all 25 firecrawl template APIs (scrape, crawl, map — all parameter variations)
- [x] Confirmed skipped tests are infrastructure-only (S3 upload, AI gateway, Tavily API key)
- [x] Zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)