### PR TITLE
Use API-based embeddings for adaptive-crawl/embedding

### DIFF
--- a/python-examples/crawl4ai/api/adaptive-crawl/embedding.py
+++ b/python-examples/crawl4ai/api/adaptive-crawl/embedding.py
@@ -6,13 +6,12 @@ Uses Intuned AI Gateway for LLM-based query expansion.
 Based on: https://docs.crawl4ai.com/core/adaptive-crawling/
 """
 
-import os
 from typing import TypedDict
 
 from intuned_runtime import get_ai_gateway_config
 from playwright.async_api import BrowserContext, Page
 
-from crawl4ai import AdaptiveConfig, AdaptiveCrawler, AsyncWebCrawler
+from crawl4ai import AdaptiveConfig, AdaptiveCrawler, AsyncWebCrawler, LLMConfig
 
 
 class Params(TypedDict, total=False):
@@ -39,16 +38,21 @@ async def automation(
     # Get AI gateway config
     base_url, api_key = get_ai_gateway_config()
 
-    # Set OpenAI environment variables for crawl4ai
-    os.environ["OPENAI_API_KEY"] = api_key
-    os.environ["OPENAI_API_BASE"] = base_url
-
     max_pages = params.get("max_pages", 20)
     top_k = params.get("top_k", 5)
 
     config = AdaptiveConfig(
         strategy="embedding",
-        embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+        embedding_llm_config=LLMConfig(
+            provider="openai/text-embedding-3-small",
+            api_token=api_key,
+            base_url=base_url,
+        ),
+        query_llm_config=LLMConfig(
+            provider="openai/gpt-4o-mini",
+            api_token=api_key,
+            base_url=base_url,
+        ),
         n_query_variations=10,
         embedding_min_confidence_threshold=0.1,
         max_pages=max_pages,

--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "playwright==1.56",
     "intuned-runtime==1.3.25",
     "intuned-browser==0.1.16",
-    "crawl4ai==0.8.6",
+    "crawl4ai[transformer]==0.8.6",
 ]
 
 [tool.uv]

--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "playwright==1.56",
     "intuned-runtime==1.3.25",
     "intuned-browser==0.1.16",
-    "crawl4ai[transformer]==0.8.6",
+    "crawl4ai==0.8.6",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Switches adaptive-crawl/embedding from local sentence-transformers to API-based embeddings via Intuned AI Gateway using LLMConfig
- Reverts crawl4ai[transformer] back to crawl4ai — removes torch (~700MB+) dependency that caused No space left on device in the sandbox
- Uses openai/text-embedding-3-small for embeddings and openai/gpt-4o-mini for query expansion, both routed through the AI gateway