### PR TITLE
quick fix

### DIFF
--- a/python-examples/browser-sdk-showcase/api/resolve-url.py
+++ b/python-examples/browser-sdk-showcase/api/resolve-url.py
@@ -26,7 +26,7 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
     # Resolve relative URL from an anchor tag
     await page.goto("https://intunedhq.com")
     url_from_anchor = await resolve_url(
-        url=page.locator("a:has-text('Schedule a demo')")
+        url=page.locator("a").first
     )
     print("Result of resolving relative URL from an anchor tag:")
     print(url_from_anchor)

--- a/typescript-examples/browser-sdk-showcase/api/resolve-url.ts
+++ b/typescript-examples/browser-sdk-showcase/api/resolve-url.ts
@@ -9,7 +9,7 @@ interface Params {
 export default async function handler(
   params: Params,
   page: Page,
-  context: BrowserContext
+  context: BrowserContext,
 ) {
   // Resolve a relative URL to an absolute URL
   const urlWithBase = await resolveUrl({
@@ -31,7 +31,7 @@ export default async function handler(
   // Resolve relative URL from an anchor tag
   await page.goto("https://intunedhq.com");
   const urlFromAnchor = await resolveUrl({
-    url: page.locator("a:has-text('Schedule a demo')"),
+    url: page.locator("a").first(),
   });
   console.log("Result of resolving relative URL from an anchor tag:");
   console.log(urlFromAnchor);
@@ -42,4 +42,3 @@ export default async function handler(
     url_from_anchor: urlFromAnchor,
   };
 }
-


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

