### PR TITLE
fix handle new tabs in py and ts

### DIFF
--- a/python-examples/playwright-basics/api/08-handle-new-tabs.py
+++ b/python-examples/playwright-basics/api/08-handle-new-tabs.py
@@ -11,14 +11,16 @@ from typing import TypedDict
 
 from playwright.async_api import Page
 
+from intuned_browser import go_to_url, wait_for_dom_settled
+
 
 class Params(TypedDict):
     pass
 
 
 async def automation(page: Page, params: Params | None = None, **_kwargs):
-    await page.goto("https://books.toscrape.com/")
-    await page.wait_for_load_state("networkidle")
+    await go_to_url(page, url="https://books.toscrape.com/")
+    await wait_for_dom_settled(source=page)
 
     # Get the first book link
     first_book_link = page.locator(".product_pod h3 a").first
@@ -26,21 +28,22 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
 
     # Method 1: Navigate in the same page
     await first_book_link.click()
-    await page.wait_for_load_state("networkidle")
+    await wait_for_dom_settled(source=page)
     book_price = await page.locator(".price_color").first.text_content()
 
-    # Go back to the list
-    await page.go_back()
-    await page.wait_for_load_state("networkidle")
+    # Go back to the list using direct navigation (more reliable than page.go_back())
+    await go_to_url(page, url="https://books.toscrape.com/")
+    await wait_for_dom_settled(source=page)
 
     # Method 2: Open in a new page (simulating target="_blank")
     # Create a new page manually from context
     context = page.context
     new_page = await context.new_page()
-    await new_page.goto(
-        "https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html"
+    await go_to_url(
+        new_page,
+        url="https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html",
     )
-    await new_page.wait_for_load_state("networkidle")
+    await wait_for_dom_settled(source=new_page)
 
     new_page_title = await new_page.locator(".product_main h1").text_content()
     new_page_price = await new_page.locator(".price_color").first.text_content()

--- a/typescript-examples/playwright-basics/api/08-handle-new-tabs.ts
+++ b/typescript-examples/playwright-basics/api/08-handle-new-tabs.ts
@@ -1,4 +1,5 @@
 import { BrowserContext, Page } from "playwright";
+import { goToUrl, waitForDomSettled } from "@intuned/browser";
 
 /**
  * Handle New Tabs and Popups
@@ -9,34 +10,35 @@ import { BrowserContext, Page } from "playwright";
  * - Working with multiple pages
  */
 
-interface Params {}
+interface Params { }
 
 export default async function handler(
   params: Params,
   page: Page,
   context: BrowserContext
 ) {
-  await page.goto("https://books.toscrape.com/");
-  await page.waitForLoadState("networkidle");
+  await goToUrl({ page, url: "https://books.toscrape.com/" });
+  await waitForDomSettled({ source: page });
 
   // Get the first book link
   const firstBookLink = page.locator(".product_pod h3 a").first();
   const bookTitle = await firstBookLink.getAttribute("title");
+  console.log(await firstBookLink.getAttribute("href"))
 
   // Method 1: Navigate in the same page
   await firstBookLink.click();
-  await page.waitForLoadState("networkidle");
+  await waitForDomSettled({ source: page });
   const bookPrice = await page.locator(".price_color").first().textContent();
 
   // Go back to the list
-  await page.goBack();
-  await page.waitForLoadState("networkidle");
+  await goToUrl({ page, url: "https://books.toscrape.com/" });
+  await waitForDomSettled({ source: page });
 
   // Method 2: Open in a new page (simulating target="_blank")
   // Create a new page manually
   const newPage = await context.newPage();
-  await newPage.goto("https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html");
-  await newPage.waitForLoadState("networkidle");
+  await goToUrl({ page: newPage, url: "https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html" });
+  await waitForDomSettled({ source: newPage });
 
   const newPageTitle = await newPage.locator(".product_main h1").textContent();
   const newPagePrice = await newPage.locator(".price_color").first().textContent();


### PR DESCRIPTION
a navigation timeout was happening
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

