### PR TITLE
fix upload file api in playwright basics

### DIFF
--- a/python-examples/playwright-basics/api/13-upload-file.py
+++ b/python-examples/playwright-basics/api/13-upload-file.py
@@ -36,11 +36,8 @@ async def automation(page: Page, params: Params | None = None, **_kwargs):
 
     # Get the signed URL for the uploaded file
     signed_url = await uploaded_file.get_signed_url()
-    file_path = uploaded_file.get_file_path()
-
     return {
         "message": "File uploaded successfully",
         "downloadedFileName": downloaded_file.suggested_filename,
-        "uploadedFilePath": file_path,
         "signedUrl": signed_url,
     }

--- a/typescript-examples/playwright-basics/api/13-upload-file.ts
+++ b/typescript-examples/playwright-basics/api/13-upload-file.ts
@@ -42,7 +42,6 @@ export default async function handler(
   return {
     message: "File uploaded successfully",
     downloadedFileName: downloadedFile.suggestedFilename,
-    uploadedFilePath: uploadedFile.getFilePath(),
     signedUrl: await uploadedFile.getSignedUrl(),
   };
 }


### PR DESCRIPTION

# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

