### PR TITLE
add note to use proxy in captcha templates

### DIFF
--- a/python-examples/captcha-in-login/README.md
+++ b/python-examples/captcha-in-login/README.md
@@ -2,6 +2,8 @@
 
 E-commerce scraper automation demonstrating Cloudflare captcha solving and stealth mode with authenticated sessions.
 
+> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
+
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
@@ -95,5 +97,6 @@ intuned dev deploy
 - [Intuned CLI](https://intunedhq.com/docs/main/05-references/cli/overview)
 - [Auth Sessions](https://intunedhq.com/docs/main/02-features/auth-sessions)
 - [Captcha Helpers](https://intunedhq.com/docs/main/05-references/runtime-sdk-python/captcha-helpers)
+- [Stealth Mode, Captcha Solving, and Proxies](https://intunedhq.com/docs/main/02-features/stealth-mode-captcha-solving-proxies#stealth-mode-captcha-solving-and-proxies)
 - [Intuned Browser SDK](https://intunedhq.com/docs/automation-sdks/overview)
 - [Intuned llm.txt](https://intunedhq.com/docs/llms.txt)

--- a/python-examples/captcha-solving-basic/README.md
+++ b/python-examples/captcha-solving-basic/README.md
@@ -2,6 +2,7 @@
 
 Basic captcha solving with support for reCAPTCHA, Cloudflare, and custom captchas.
 
+> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
@@ -71,5 +72,6 @@ intuned dev deploy
 
 - [Intuned CLI](https://intunedhq.com/docs/main/05-references/cli/overview)
 - [Captcha Helpers](https://intunedhq.com/docs/main/05-references/runtime-sdk-python/captcha-helpers)
+- [Stealth Mode, Captcha Solving, and Proxies](https://intunedhq.com/docs/main/02-features/stealth-mode-captcha-solving-proxies#stealth-mode-captcha-solving-and-proxies)
 - [Intuned Browser SDK](https://intunedhq.com/docs/automation-sdks/overview)
 - [Intuned llm.txt](https://intunedhq.com/docs/llms.txt)

--- a/typescript-examples/captcha-in-login/README.md
+++ b/typescript-examples/captcha-in-login/README.md
@@ -2,6 +2,8 @@
 
 E-commerce scraper automation demonstrating Cloudflare captcha solving with authenticated sessions.
 
+> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
+
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
@@ -97,5 +99,6 @@ intuned dev deploy
 - [Intuned CLI](https://intunedhq.com/docs/main/05-references/cli/overview)
 - [Auth Sessions](https://intunedhq.com/docs/main/02-features/auth-sessions)
 - [Captcha Helpers](https://intunedhq.com/docs/main/05-references/runtime-sdk-typescript/captcha-helpers)
+- [Stealth Mode, Captcha Solving, and Proxies](https://intunedhq.com/docs/main/02-features/stealth-mode-captcha-solving-proxies#stealth-mode-captcha-solving-and-proxies)
 - [Intuned Browser SDK](https://intunedhq.com/docs/automation-sdks/overview)
 - [Intuned llm.txt](https://intunedhq.com/docs/llms.txt)

--- a/typescript-examples/captcha-solving-basic/README.md
+++ b/typescript-examples/captcha-solving-basic/README.md
@@ -2,6 +2,7 @@
 
 Basic captcha solving with support for reCAPTCHA, Cloudflare, and custom captchas
 
+> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned
 
@@ -73,5 +74,6 @@ intuned dev deploy
 
 - [Intuned CLI](https://intunedhq.com/docs/main/05-references/cli/overview)
 - [Captcha Helpers](https://intunedhq.com/docs/main/05-references/runtime-sdk-typescript/captcha-helpers)
+- [Stealth Mode, Captcha Solving, and Proxies](https://intunedhq.com/docs/main/02-features/stealth-mode-captcha-solving-proxies#stealth-mode-captcha-solving-and-proxies)
 - [Intuned Browser SDK](https://intunedhq.com/docs/automation-sdks/overview)
 - [Intuned llm.txt](https://intunedhq.com/docs/llms.txt)


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

