### PR TITLE
fix readme to deploy project at first for AI templates

### DIFF
--- a/typescript-examples/hybrid-automation/README.md
+++ b/typescript-examples/hybrid-automation/README.md
@@ -36,6 +36,18 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
+### Save project
+
+```bash
+intuned dev provision
+```
+### Deploy
+
+```bash
+intuned dev deploy
+```
+
+
 ### Run an API
 
 ```bash
@@ -47,17 +59,7 @@ intuned dev run api crawler/crawl .parameters/api/crawler/crawl/job-posting.json
 intuned dev run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
 ```
 
-### Save project
 
-```bash
-intuned dev provision
-```
-
-### Deploy
-
-```bash
-intuned dev deploy
-```
 <!-- IDE-IGNORE-END -->
 
 ## Project structure


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

