### PR TITLE
move provision instruction at first in readme for AI scrapers

### DIFF
--- a/python-examples/hybrid-automation/README.md
+++ b/python-examples/hybrid-automation/README.md
@@ -34,17 +34,6 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
-### Run an API
-
-```bash
-intuned dev run api rpa/fill-form .parameters/api/rpa/fill-form/default.json
-intuned dev run api scraper/list .parameters/api/scraper/list/default.json
-intuned dev run api scraper/details .parameters/api/scraper/details/default.json
-intuned dev run api crawler/crawl .parameters/api/crawler/crawl/default.json
-intuned dev run api crawler/crawl .parameters/api/crawler/crawl/job-posting.json
-intuned dev run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
-```
-
 ### Save project
 
 ```bash
@@ -56,6 +45,18 @@ intuned dev provision
 ```bash
 intuned dev deploy
 ```
+
+### Run an API
+
+```bash
+intuned dev run api rpa/fill-form .parameters/api/rpa/fill-form/default.json
+intuned dev run api scraper/list .parameters/api/scraper/list/default.json
+intuned dev run api scraper/details .parameters/api/scraper/details/default.json
+intuned dev run api crawler/crawl .parameters/api/crawler/crawl/default.json
+intuned dev run api crawler/crawl .parameters/api/crawler/crawl/job-posting.json
+intuned dev run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
+```
+
 <!-- IDE-IGNORE-END -->
 
 ## Project structure

--- a/python-examples/rpa-forms-example/README.md
+++ b/python-examples/rpa-forms-example/README.md
@@ -29,13 +29,6 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
-### Run an API
-
-```bash
-intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/default.json
-intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/honda.json
-```
-
 ### Save project
 
 ```bash
@@ -46,6 +39,14 @@ intuned dev provision
 
 ```bash
 intuned dev deploy
+
+### Run an API
+
+```bash
+intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/default.json
+intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/honda.json
+```
+
 ```
 <!-- IDE-IGNORE-END -->
 

--- a/python-examples/stagehand/README.md
+++ b/python-examples/stagehand/README.md
@@ -29,13 +29,6 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
-### Run an API
-
-```bash
-intuned dev run api get-books .parameters/api/get-books/travel-category.json
-intuned dev run api get-books .parameters/api/get-books/no-category-all-books.json
-```
-
 ### Save project
 
 ```bash
@@ -47,6 +40,14 @@ intuned dev provision
 ```bash
 intuned dev deploy
 ```
+
+### Run an API
+
+```bash
+intuned dev run api get-books .parameters/api/get-books/travel-category.json
+intuned dev run api get-books .parameters/api/get-books/no-category-all-books.json
+```
+
 <!-- IDE-IGNORE-END -->
 
 ## Project Structure

--- a/typescript-examples/hybrid-automation/README.md
+++ b/typescript-examples/hybrid-automation/README.md
@@ -36,17 +36,6 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
-### Run an API
-
-```bash
-intuned dev run api rpa/fill-form .parameters/api/rpa/fill-form/default.json
-intuned dev run api scraper/list .parameters/api/scraper/list/default.json
-intuned dev run api scraper/details .parameters/api/scraper/details/default.json
-intuned dev run api crawler/crawl .parameters/api/crawler/crawl/default.json
-intuned dev run api crawler/crawl .parameters/api/crawler/crawl/job-posting.json
-intuned dev run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
-```
-
 ### Save project
 
 ```bash
@@ -58,6 +47,18 @@ intuned dev provision
 ```bash
 intuned dev deploy
 ```
+
+### Run an API
+
+```bash
+intuned dev run api rpa/fill-form .parameters/api/rpa/fill-form/default.json
+intuned dev run api scraper/list .parameters/api/scraper/list/default.json
+intuned dev run api scraper/details .parameters/api/scraper/details/default.json
+intuned dev run api crawler/crawl .parameters/api/crawler/crawl/default.json
+intuned dev run api crawler/crawl .parameters/api/crawler/crawl/job-posting.json
+intuned dev run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
+```
+
 <!-- IDE-IGNORE-END -->
 
 ## Project structure

--- a/typescript-examples/rpa-forms-example/README.md
+++ b/typescript-examples/rpa-forms-example/README.md
@@ -31,13 +31,6 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
-### Run an API
-
-```bash
-intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/default.json
-intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/honda.json
-```
-
 ### Save project
 
 ```bash
@@ -49,6 +42,14 @@ intuned dev provision
 ```bash
 intuned dev deploy
 ```
+
+### Run an API
+
+```bash
+intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/default.json
+intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/honda.json
+```
+
 <!-- IDE-IGNORE-END -->
 
 ## Project Structure


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

