### PR TITLE
move provision instruction before execute in AI README

### DIFF
--- a/python-examples/hybrid-automation/README.md
+++ b/python-examples/hybrid-automation/README.md
@@ -34,6 +34,15 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
+### Prepare the project
+
+Before running any API, provision and deploy the project first.
+
+```bash
+intuned dev provision
+intuned dev deploy
+```
+
 ### Run an API
 
 ```bash
@@ -43,18 +52,6 @@ intuned dev run api scraper/details .parameters/api/scraper/details/default.json
 intuned dev run api crawler/crawl .parameters/api/crawler/crawl/default.json
 intuned dev run api crawler/crawl .parameters/api/crawler/crawl/job-posting.json
 intuned dev run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
-```
-
-### Save project
-
-```bash
-intuned dev provision
-```
-
-### Deploy
-
-```bash
-intuned dev deploy
 ```
 <!-- IDE-IGNORE-END -->
 

--- a/python-examples/rpa-forms-example/README.md
+++ b/python-examples/rpa-forms-example/README.md
@@ -29,23 +29,20 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
+### Prepare the project
+
+Before running any API, provision and deploy the project first.
+
+```bash
+intuned dev provision
+intuned dev deploy
+```
+
 ### Run an API
 
 ```bash
 intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/default.json
 intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/honda.json
-```
-
-### Save project
-
-```bash
-intuned dev provision
-```
-
-### Deploy
-
-```bash
-intuned dev deploy
 ```
 <!-- IDE-IGNORE-END -->
 

--- a/python-examples/stagehand/README.md
+++ b/python-examples/stagehand/README.md
@@ -29,23 +29,20 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
+### Prepare the project
+
+Before running any API, provision and deploy the project first.
+
+```bash
+intuned dev provision
+intuned dev deploy
+```
+
 ### Run an API
 
 ```bash
 intuned dev run api get-books .parameters/api/get-books/travel-category.json
 intuned dev run api get-books .parameters/api/get-books/no-category-all-books.json
-```
-
-### Save project
-
-```bash
-intuned dev provision
-```
-
-### Deploy
-
-```bash
-intuned dev deploy
 ```
 <!-- IDE-IGNORE-END -->
 

--- a/typescript-examples/hybrid-automation/README.md
+++ b/typescript-examples/hybrid-automation/README.md
@@ -36,6 +36,15 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
+### Prepare the project
+
+Before running any API, provision and deploy the project first.
+
+```bash
+intuned dev provision
+intuned dev deploy
+```
+
 ### Run an API
 
 ```bash
@@ -45,18 +54,6 @@ intuned dev run api scraper/details .parameters/api/scraper/details/default.json
 intuned dev run api crawler/crawl .parameters/api/crawler/crawl/default.json
 intuned dev run api crawler/crawl .parameters/api/crawler/crawl/job-posting.json
 intuned dev run api crawler/crawl .parameters/api/crawler/crawl/not-lever.json
-```
-
-### Save project
-
-```bash
-intuned dev provision
-```
-
-### Deploy
-
-```bash
-intuned dev deploy
 ```
 <!-- IDE-IGNORE-END -->
 

--- a/typescript-examples/rpa-forms-example/README.md
+++ b/typescript-examples/rpa-forms-example/README.md
@@ -31,23 +31,20 @@ npm install -g @intuned/cli
 
 After installing dependencies, `intuned` command should be available in your environment.
 
+### Prepare the project
+
+Before running any API, provision and deploy the project first.
+
+```bash
+intuned dev provision
+intuned dev deploy
+```
+
 ### Run an API
 
 ```bash
 intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/default.json
 intuned dev run api insurance-form-filler .parameters/api/insurance-form-filler/honda.json
-```
-
-### Save project
-
-```bash
-intuned dev provision
-```
-
-### Deploy
-
-```bash
-intuned dev deploy
 ```
 <!-- IDE-IGNORE-END -->
 

--- a/typescript-examples/stagehand/README.md
+++ b/typescript-examples/stagehand/README.md
@@ -29,27 +29,20 @@ If the `intuned` CLI is not installed, install it globally:
 npm install -g @intuned/cli
 ```
 
-After installing dependencies, `intuned` command should be available in your environment.
+### Prepare the project
 
-**Important:** This example uses Stagehand with Intuned's AI gateway. Run `intuned dev provision` once before running any APIs so the AI gateway is configured for local runs.
+Before running any API, provision and deploy the project first.
+
+```bash
+intuned dev provision
+intuned dev deploy
+```
 
 ### Run an API
 
 ```bash
 intuned dev run api get-books .parameters/api/get-books/travel-category.json
 intuned dev run api get-books .parameters/api/get-books/no-category-all-books.json
-```
-
-### Save project
-
-```bash
-intuned dev provision
-```
-
-### Deploy
-
-```bash
-intuned dev deploy
 ```
 <!-- IDE-IGNORE-END -->
 


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

