### PR TITLE
add proxy note in captcha templates

### DIFF
--- a/python-examples/captcha-in-login/README.md
+++ b/python-examples/captcha-in-login/README.md
@@ -2,7 +2,7 @@
 
 E-commerce scraper automation demonstrating Cloudflare captcha solving and stealth mode with authenticated sessions.
 
-> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
+> **Note:** This template only works on the Intuned platform. A proxy must be configured in order to run it.
 
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned

--- a/python-examples/captcha-solving-basic/README.md
+++ b/python-examples/captcha-solving-basic/README.md
@@ -2,7 +2,7 @@
 
 Basic captcha solving with support for reCAPTCHA, Cloudflare, and custom captchas.
 
-> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
+> **Note:** This template only works on the Intuned platform. A proxy must be configured in order to run it.
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned
 

--- a/typescript-examples/captcha-in-login/README.md
+++ b/typescript-examples/captcha-in-login/README.md
@@ -2,7 +2,7 @@
 
 E-commerce scraper automation demonstrating Cloudflare captcha solving with authenticated sessions.
 
-> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
+> **Note:** This template only works on the Intuned platform. A proxy must be configured in order to run it.
 
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned

--- a/typescript-examples/captcha-solving-basic/README.md
+++ b/typescript-examples/captcha-solving-basic/README.md
@@ -2,7 +2,7 @@
 
 Basic captcha solving with support for reCAPTCHA, Cloudflare, and custom captchas
 
-> **Note:** In order to work properly, a proxy must be configured for captcha solving. Use the `--proxy <url>` flag when running APIs.
+> **Note:** This template only works on the Intuned platform. A proxy must be configured in order to run it.
 <!-- IDE-IGNORE-START -->
 ## Run on Intuned
 


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

