### PR TITLE
Release python runtime + clean useless flags

### DIFF
--- a/python-examples/auth-with-email-otp/pyproject.toml
+++ b/python-examples/auth-with-email-otp/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
     "resend>=2.0.0",

--- a/python-examples/auth-with-secret-otp/pyproject.toml
+++ b/python-examples/auth-with-secret-otp/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
     "pyotp==2.9.0",

--- a/python-examples/browser-sdk-showcase/pyproject.toml
+++ b/python-examples/browser-sdk-showcase/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/browser-use/pyproject.toml
+++ b/python-examples/browser-use/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "browser-use==0.11.2",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/bs4/pyproject.toml
+++ b/python-examples/bs4/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "beautifulsoup4==4.14.3",
     "pydantic>=2.12.5",

--- a/python-examples/captcha-in-login/Intuned.jsonc
+++ b/python-examples/captcha-in-login/Intuned.jsonc
@@ -4,8 +4,7 @@
   },
   "authSessions": {
     "enabled": true,
-    "type": "API",
-    "saveTraces": true
+    "type": "API"
   },
   "replication": {
     "maxConcurrentRequests": 1,

--- a/python-examples/captcha-in-login/pyproject.toml
+++ b/python-examples/captcha-in-login/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56.0",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/captcha-solving-basic/pyproject.toml
+++ b/python-examples/captcha-solving-basic/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/cdp-connection/pyproject.toml
+++ b/python-examples/cdp-connection/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "httpx==0.28.1",
     "pydantic>=2.0.0",

--- a/python-examples/computer-use/pyproject.toml
+++ b/python-examples/computer-use/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",
     "python-dateutil~=2.9.0",

--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",
 ]

--- a/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",
 ]

--- a/python-examples/e-commerce-nested/pyproject.toml
+++ b/python-examples/e-commerce-nested/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",
 ]

--- a/python-examples/e-commerce-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-scrapingcourse/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",
 ]

--- a/python-examples/e-commerce-shopify/pyproject.toml
+++ b/python-examples/e-commerce-shopify/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/firecrawl/pyproject.toml
+++ b/python-examples/firecrawl/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",
     "pytz>=2024.1",

--- a/python-examples/hybrid-automation/pyproject.toml
+++ b/python-examples/hybrid-automation/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",
     "openai~=1.0",

--- a/python-examples/native-crawler/pyproject.toml
+++ b/python-examples/native-crawler/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/network-interception/pyproject.toml
+++ b/python-examples/network-interception/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",
 ]

--- a/python-examples/playwright-basics/pyproject.toml
+++ b/python-examples/playwright-basics/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/quick-recipes/pyproject.toml
+++ b/python-examples/quick-recipes/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/rpa-auth-example/pyproject.toml
+++ b/python-examples/rpa-auth-example/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
 ]

--- a/python-examples/rpa-example/pyproject.toml
+++ b/python-examples/rpa-example/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
 ]

--- a/python-examples/rpa-forms-example/pyproject.toml
+++ b/python-examples/rpa-forms-example/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "stagehand==3.5.0",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/scrapy/pyproject.toml
+++ b/python-examples/scrapy/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic>=2.10.6",
     "scrapy>=2.13.4",

--- a/python-examples/setup-hooks/pyproject.toml
+++ b/python-examples/setup-hooks/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic>=2.0.0",
 ]

--- a/python-examples/stagehand/pyproject.toml
+++ b/python-examples/stagehand/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",
     "python-dateutil~=2.9.0",

--- a/python-examples/starter-auth/pyproject.toml
+++ b/python-examples/starter-auth/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
 ]

--- a/python-examples/starter/pyproject.toml
+++ b/python-examples/starter/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.26",
+    "intuned-runtime==1.3.27",
     "intuned-browser==0.1.17",
 ]
 

--- a/typescript-examples/captcha-in-login/Intuned.jsonc
+++ b/typescript-examples/captcha-in-login/Intuned.jsonc
@@ -4,8 +4,7 @@
   },
   "authSessions": {
     "enabled": true,
-    "type": "API",
-    "saveTraces": true
+    "type": "API"
   },
   "replication": {
     "maxConcurrentRequests": 1,


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

