### PR TITLE
add enve var instrcutions in readme for py and ts

### DIFF
--- a/python-examples/auth-with-email-otp/README.md
+++ b/python-examples/auth-with-email-otp/README.md
@@ -14,6 +14,14 @@ Authentication example using email-based OTP verification with Resend.
 | --- | ----------- |
 | `list-contracts` | Lists contracts for the authenticated user from the sandbox site |
 
+
+
+### Prerequisites (IDE only)
+
+- A Resend account with a "Receiving Emails" inbox configured (used to receive OTPs).
+- Add your Resend API key to the environment as `RESEND_API_KEY`. See [Environment variables and secrets](https://intunedhq.com/docs/main/02-features/environment-variables-secrets#create-an-environment-variable) for instructions.
+
+
 <!-- IDE-IGNORE-START -->
 
 ### Prerequisites

--- a/python-examples/auth-with-email-otp/README.md
+++ b/python-examples/auth-with-email-otp/README.md
@@ -18,7 +18,7 @@ Authentication example using email-based OTP verification with Resend.
 
 ### Prerequisites (IDE only)
 
-- A Resend account with a "Receiving Emails" inbox configured (used to receive OTPs).
+- A [Resend](https://resend.com) account with a "Receiving Emails" inbox configured (used to receive OTPs).
 - Add your Resend API key to the environment as `RESEND_API_KEY`. See [Environment variables and secrets](https://intunedhq.com/docs/main/02-features/environment-variables-secrets#create-an-environment-variable) for instructions.
 
 

--- a/typescript-examples/auth-with-email-otp/README.md
+++ b/typescript-examples/auth-with-email-otp/README.md
@@ -14,6 +14,12 @@ Authentication example using email-based OTP verification with Resend.
 | --- | ----------- |
 | `list-contracts` | Lists contracts for the authenticated user from the sandbox site |
 
+
+### Prerequisites (IDE only)
+
+- A Resend account with a "Receiving Emails" inbox configured (used to receive OTPs).
+- Add your Resend API key to the environment as `RESEND_API_KEY`. See [Environment variables and secrets](https://intunedhq.com/docs/main/02-features/environment-variables-secrets#create-an-environment-variable) for instructions.
+
 <!-- IDE-IGNORE-START -->
 
 ### Prerequisites

--- a/typescript-examples/auth-with-email-otp/README.md
+++ b/typescript-examples/auth-with-email-otp/README.md
@@ -17,7 +17,7 @@ Authentication example using email-based OTP verification with Resend.
 
 ### Prerequisites (IDE only)
 
-- A Resend account with a "Receiving Emails" inbox configured (used to receive OTPs).
+- A [Resend](https://resend.com) account with a "Receiving Emails" inbox configured (used to receive OTPs).
 - Add your Resend API key to the environment as `RESEND_API_KEY`. See [Environment variables and secrets](https://intunedhq.com/docs/main/02-features/environment-variables-secrets#create-an-environment-variable) for instructions.
 
 <!-- IDE-IGNORE-START -->


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

