### PR TITLE
upgrade default to playwright 1.61

### DIFF
--- a/TEMPLATE_SPEC.md
+++ b/TEMPLATE_SPEC.md
@@ -426,7 +426,7 @@ Use `corepack use yarn@1.22.22` when you need to generate the `packageManager` f
     "@intuned/browser": "0.1.13",
     "@intuned/runtime": "1.3.12",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }
 ```
@@ -447,7 +447,7 @@ requires-python = ">=3.12,<3.13"
 readme = "README.md"
 keywords = ["Python", "intuned-browser-sdk"]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.12",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/auth-with-email-otp/pyproject.toml
+++ b/python-examples/auth-with-email-otp/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "intuned-auth-sessions-credentials"
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/auth-with-email-otp/pyproject.toml
+++ b/python-examples/auth-with-email-otp/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "intuned-auth-sessions-credentials"
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/auth-with-secret-otp/pyproject.toml
+++ b/python-examples/auth-with-secret-otp/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/auth-with-secret-otp/pyproject.toml
+++ b/python-examples/auth-with-secret-otp/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/browser-sdk-showcase/pyproject.toml
+++ b/python-examples/browser-sdk-showcase/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/browser-sdk-showcase/pyproject.toml
+++ b/python-examples/browser-sdk-showcase/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/browser-use/pyproject.toml
+++ b/python-examples/browser-use/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "browser-use==0.11.2",
     "intuned-browser==0.1.17",

--- a/python-examples/browser-use/pyproject.toml
+++ b/python-examples/browser-use/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "browser-use==0.11.2",
     "intuned-browser==0.1.17",

--- a/python-examples/bs4/pyproject.toml
+++ b/python-examples/bs4/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "beautifulsoup4==4.14.3",

--- a/python-examples/bs4/pyproject.toml
+++ b/python-examples/bs4/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "beautifulsoup4==4.14.3",

--- a/python-examples/captcha-in-login/pyproject.toml
+++ b/python-examples/captcha-in-login/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "captcha-solving",
 ]
 dependencies = [
-    "playwright==1.56.0",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/captcha-in-login/pyproject.toml
+++ b/python-examples/captcha-in-login/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "captcha-solving",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/captcha-solving-basic/pyproject.toml
+++ b/python-examples/captcha-solving-basic/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "captcha-solving",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/captcha-solving-basic/pyproject.toml
+++ b/python-examples/captcha-solving-basic/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "captcha-solving",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/cdp-connection/pyproject.toml
+++ b/python-examples/cdp-connection/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "Python",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "httpx==0.28.1",

--- a/python-examples/cdp-connection/pyproject.toml
+++ b/python-examples/cdp-connection/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "Python",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "httpx==0.28.1",

--- a/python-examples/computer-use/pyproject.toml
+++ b/python-examples/computer-use/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/computer-use/pyproject.toml
+++ b/python-examples/computer-use/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",

--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",

--- a/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",

--- a/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",

--- a/python-examples/e-commerce-nested/pyproject.toml
+++ b/python-examples/e-commerce-nested/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",

--- a/python-examples/e-commerce-nested/pyproject.toml
+++ b/python-examples/e-commerce-nested/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",

--- a/python-examples/e-commerce-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-scrapingcourse/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",

--- a/python-examples/e-commerce-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-scrapingcourse/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",

--- a/python-examples/e-commerce-shopify/pyproject.toml
+++ b/python-examples/e-commerce-shopify/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/e-commerce-shopify/pyproject.toml
+++ b/python-examples/e-commerce-shopify/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/firecrawl/pyproject.toml
+++ b/python-examples/firecrawl/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "crawl4ai",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",

--- a/python-examples/firecrawl/pyproject.toml
+++ b/python-examples/firecrawl/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "crawl4ai",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",

--- a/python-examples/hybrid-automation/pyproject.toml
+++ b/python-examples/hybrid-automation/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/hybrid-automation/pyproject.toml
+++ b/python-examples/hybrid-automation/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/native-crawler/pyproject.toml
+++ b/python-examples/native-crawler/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/native-crawler/pyproject.toml
+++ b/python-examples/native-crawler/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/network-interception/pyproject.toml
+++ b/python-examples/network-interception/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",

--- a/python-examples/network-interception/pyproject.toml
+++ b/python-examples/network-interception/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",

--- a/python-examples/playwright-basics/pyproject.toml
+++ b/python-examples/playwright-basics/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/playwright-basics/pyproject.toml
+++ b/python-examples/playwright-basics/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/quick-recipes/pyproject.toml
+++ b/python-examples/quick-recipes/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/quick-recipes/pyproject.toml
+++ b/python-examples/quick-recipes/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/rpa-auth-example/pyproject.toml
+++ b/python-examples/rpa-auth-example/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/rpa-auth-example/pyproject.toml
+++ b/python-examples/rpa-auth-example/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/rpa-example/pyproject.toml
+++ b/python-examples/rpa-example/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/rpa-example/pyproject.toml
+++ b/python-examples/rpa-example/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/rpa-forms-example/pyproject.toml
+++ b/python-examples/rpa-forms-example/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "stagehand==3.5.0",
     "intuned-browser==0.1.17",

--- a/python-examples/rpa-forms-example/pyproject.toml
+++ b/python-examples/rpa-forms-example/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "stagehand==3.5.0",
     "intuned-browser==0.1.17",

--- a/python-examples/scrapy/pyproject.toml
+++ b/python-examples/scrapy/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic>=2.10.6",

--- a/python-examples/scrapy/pyproject.toml
+++ b/python-examples/scrapy/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic>=2.10.6",

--- a/python-examples/setup-hooks/pyproject.toml
+++ b/python-examples/setup-hooks/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "Python",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic>=2.0.0",

--- a/python-examples/setup-hooks/pyproject.toml
+++ b/python-examples/setup-hooks/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "Python",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic>=2.0.0",

--- a/python-examples/stagehand/pyproject.toml
+++ b/python-examples/stagehand/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/stagehand/pyproject.toml
+++ b/python-examples/stagehand/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "intuned-runtime-sdk-setup-context-hook",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/starter-auth/pyproject.toml
+++ b/python-examples/starter-auth/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/starter-auth/pyproject.toml
+++ b/python-examples/starter-auth/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",

--- a/python-examples/starter-crawl4ai/pyproject.toml
+++ b/python-examples/starter-crawl4ai/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",

--- a/python-examples/starter-crawl4ai/pyproject.toml
+++ b/python-examples/starter-crawl4ai/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",

--- a/python-examples/starter-network-interception/pyproject.toml
+++ b/python-examples/starter-network-interception/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/starter-network-interception/pyproject.toml
+++ b/python-examples/starter-network-interception/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/starter-rpa/pyproject.toml
+++ b/python-examples/starter-rpa/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/starter-rpa/pyproject.toml
+++ b/python-examples/starter-rpa/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/starter-scrapy/pyproject.toml
+++ b/python-examples/starter-scrapy/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "scrapy>=2.13.4",

--- a/python-examples/starter-scrapy/pyproject.toml
+++ b/python-examples/starter-scrapy/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "scrapy>=2.13.4",

--- a/python-examples/starter-shopify/pyproject.toml
+++ b/python-examples/starter-shopify/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/starter-shopify/pyproject.toml
+++ b/python-examples/starter-shopify/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/starter-stagehand/pyproject.toml
+++ b/python-examples/starter-stagehand/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/starter-stagehand/pyproject.toml
+++ b/python-examples/starter-stagehand/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "starter",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",

--- a/python-examples/starter/pyproject.toml
+++ b/python-examples/starter/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.56",
+    "playwright==1.61.1",
     "intuned-runtime==1.3.33",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/starter/pyproject.toml
+++ b/python-examples/starter/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "intuned-browser-sdk",
 ]
 dependencies = [
-    "playwright==1.61.1",
+    "playwright==1.61.0",
     "intuned-runtime==1.3.36",
     "intuned-browser==0.1.17",
 ]

--- a/typescript-examples/auth-with-email-otp/package.json
+++ b/typescript-examples/auth-with-email-otp/package.json
@@ -18,7 +18,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "resend": "^6.6.0",
     "zod": "^3.22.4"
   },

--- a/typescript-examples/auth-with-secret-otp/package.json
+++ b/typescript-examples/auth-with-secret-otp/package.json
@@ -19,7 +19,7 @@
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
     "otplib": "^12.0.1",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/browser-sdk-showcase/package.json
+++ b/typescript-examples/browser-sdk-showcase/package.json
@@ -16,6 +16,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/captcha-in-login/package.json
+++ b/typescript-examples/captcha-in-login/package.json
@@ -16,6 +16,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/captcha-solving-basic/package.json
+++ b/typescript-examples/captcha-solving-basic/package.json
@@ -16,6 +16,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/cdp-connection/package.json
+++ b/typescript-examples/cdp-connection/package.json
@@ -14,7 +14,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/computer-use/package.json
+++ b/typescript-examples/computer-use/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^20.10.3",
     "luxon": "^3.7.2",
     "openai": "^6.10.0",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "3.25.67"
   }
 }

--- a/typescript-examples/e-commerce-auth-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/package.json
@@ -19,7 +19,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/e-commerce-nested/package.json
+++ b/typescript-examples/e-commerce-nested/package.json
@@ -14,7 +14,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/e-commerce-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-scrapingcourse/package.json
@@ -13,7 +13,7 @@
         "@intuned/browser": "0.1.16",
         "@intuned/runtime": "1.3.29",
         "@types/node": "^20.10.3",
-        "playwright": "~1.56.0",
+        "playwright": "~1.61.1",
         "zod": "^3.22.4"
     }
 }

--- a/typescript-examples/e-commerce-shopify/package.json
+++ b/typescript-examples/e-commerce-shopify/package.json
@@ -14,7 +14,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/hybrid-automation/package.json
+++ b/typescript-examples/hybrid-automation/package.json
@@ -23,7 +23,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "3.25.67"
   }
 }

--- a/typescript-examples/jsdom/package.json
+++ b/typescript-examples/jsdom/package.json
@@ -15,7 +15,7 @@
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
     "jsdom": "^26.1.0",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/native-crawler/package.json
+++ b/typescript-examples/native-crawler/package.json
@@ -15,7 +15,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/typescript-examples/network-interception/package.json
+++ b/typescript-examples/network-interception/package.json
@@ -14,7 +14,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/playwright-basics/package.json
+++ b/typescript-examples/playwright-basics/package.json
@@ -16,6 +16,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/quick-recipes/package.json
+++ b/typescript-examples/quick-recipes/package.json
@@ -16,6 +16,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/rpa-auth-example/package.json
+++ b/typescript-examples/rpa-auth-example/package.json
@@ -19,7 +19,7 @@
         "@intuned/browser": "0.1.16",
         "@intuned/runtime": "1.3.29",
         "@types/node": "^20.10.3",
-        "playwright": "~1.56.0",
+        "playwright": "~1.61.1",
         "zod": "^3.22.4"
     }
 }

--- a/typescript-examples/rpa-example/package.json
+++ b/typescript-examples/rpa-example/package.json
@@ -14,7 +14,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/rpa-forms-example/package.json
+++ b/typescript-examples/rpa-forms-example/package.json
@@ -23,7 +23,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "3.25.67"
   }
 }

--- a/typescript-examples/setup-hooks/package.json
+++ b/typescript-examples/setup-hooks/package.json
@@ -14,7 +14,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/stagehand/package.json
+++ b/typescript-examples/stagehand/package.json
@@ -20,7 +20,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "3.25.67"
   }
 }

--- a/typescript-examples/starter-auth/package.json
+++ b/typescript-examples/starter-auth/package.json
@@ -19,7 +19,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "^3.22.4"
   }
 }

--- a/typescript-examples/starter-jsdom/package.json
+++ b/typescript-examples/starter-jsdom/package.json
@@ -14,6 +14,6 @@
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
     "jsdom": "^26.1.0",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/starter-network-interception/package.json
+++ b/typescript-examples/starter-network-interception/package.json
@@ -13,6 +13,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/starter-rpa/package.json
+++ b/typescript-examples/starter-rpa/package.json
@@ -13,6 +13,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/starter-shopify/package.json
+++ b/typescript-examples/starter-shopify/package.json
@@ -13,6 +13,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }

--- a/typescript-examples/starter-stagehand/package.json
+++ b/typescript-examples/starter-stagehand/package.json
@@ -15,7 +15,7 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0",
+    "playwright": "~1.61.1",
     "zod": "3.25.67"
   }
 }

--- a/typescript-examples/starter/package.json
+++ b/typescript-examples/starter/package.json
@@ -16,6 +16,6 @@
     "@intuned/browser": "0.1.16",
     "@intuned/runtime": "1.3.29",
     "@types/node": "^20.10.3",
-    "playwright": "~1.56.0"
+    "playwright": "~1.61.1"
   }
 }


### PR DESCRIPTION
# Template PR Checklist

- [ ] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

