### PR TITLE
update intuned.jsonc with new settings format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,8 @@
 
 - [ ] Template exists in both TypeScript and Python (or noted why only one language)
 - [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
-- [ ] `testParameters/` directory exists for each API (and AuthSession if applicable)
-- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
+- [ ] `.parameters/` directory exists for each API (and AuthSession if applicable)
+- [ ] Jobs and Auth Sessions added to `intuned-resources` if applicable.
 - [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
 - [ ] Main README and language-specific README updated if adding/modifying examples
 

--- a/.github/scripts/validate-templates.sh
+++ b/.github/scripts/validate-templates.sh
@@ -163,6 +163,19 @@ validate_template() {
     fi
 
     # -------------------------------------------
+    # 3a. Validate top-level version (number.number format)
+    # -------------------------------------------
+    local version
+    version=$(echo "$config" | jq -r '.version // empty' 2>/dev/null || echo "")
+    if [[ -z "$version" ]]; then
+        error "[$full_path] Missing top-level 'version' field in Intuned.jsonc (expected e.g. \"2.0\")"
+    elif [[ ! "$version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        error "[$full_path] version '$version' must be in 'number.number' format (e.g. \"2.0\")"
+    else
+        success "[$full_path] version is valid: $version"
+    fi
+
+    # -------------------------------------------
     # 3b. Check tags (validate against allowed list)
     # Tags can be at metadata.template.tags or metadata.tags
     # -------------------------------------------
@@ -326,22 +339,23 @@ validate_template() {
     fi
 
     # -------------------------------------------
+    # 3g. Check replication.maxCount is a non-negative integer (when present)
+    # -------------------------------------------
+    local max_count
+    max_count=$(echo "$config" | jq -r '.replication.maxCount // empty' 2>/dev/null || echo "")
+    if [[ -n "$max_count" ]]; then
+        if [[ ! "$max_count" =~ ^[0-9]+$ ]]; then
+            error "[$full_path] replication.maxCount '$max_count' must be a non-negative integer"
+        else
+            success "[$full_path] replication.maxCount is valid: $max_count"
+        fi
+    fi
+
+    # -------------------------------------------
     # 4. Check authSessions configuration
     # -------------------------------------------
     local auth_enabled
     auth_enabled=$(echo "$config" | jq -r '.authSessions.enabled // false' 2>/dev/null || echo "false")
-
-    # -------------------------------------------
-    # 5. Check apiAccess.enabled (only warn if auth is enabled)
-    # -------------------------------------------
-    local api_access
-    api_access=$(echo "$config" | jq '.apiAccess.enabled' 2>/dev/null || echo "null")
-
-    if [[ "$api_access" == "null" && "$auth_enabled" == "true" ]]; then
-        error "[$full_path] apiAccess.enabled is not explicitly set in Intuned.jsonc (required when auth is enabled)"
-    elif [[ "$api_access" != "null" ]]; then
-        success "[$full_path] apiAccess.enabled is set to: $api_access"
-    fi
 
     if [[ "$auth_enabled" == "true" ]]; then
         info "[$full_path] Auth sessions are enabled"

--- a/python-examples/auth-with-email-otp/Intuned.jsonc
+++ b/python-examples/auth-with-email-otp/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -23,5 +20,6 @@
       "parameters": {
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/auth-with-email-otp/pyproject.toml
+++ b/python-examples/auth-with-email-otp/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
     "resend>=2.0.0",

--- a/python-examples/auth-with-secret-otp/Intuned.jsonc
+++ b/python-examples/auth-with-secret-otp/Intuned.jsonc
@@ -1,14 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -20,5 +17,6 @@
       "apiName": "list-contracts",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/auth-with-secret-otp/pyproject.toml
+++ b/python-examples/auth-with-secret-otp/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
     "pyotp==2.9.0",

--- a/python-examples/browser-sdk-showcase/Intuned.jsonc
+++ b/python-examples/browser-sdk-showcase/Intuned.jsonc
@@ -1,17 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  // "workspaceId": "your-workspace-id", // Add your workspace ID here for local development (required for AI helpers)
-  // "projectName": "your-project-name", // Add your project name here for local development (required for AI helpers)
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "proxy": {
     "enabled": false
@@ -29,5 +25,6 @@
         "retries": 3
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/browser-sdk-showcase/pyproject.toml
+++ b/python-examples/browser-sdk-showcase/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/browser-use/Intuned.jsonc
+++ b/python-examples/browser-use/Intuned.jsonc
@@ -1,17 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  // "workspaceId": "your-workspace-id", // Add your workspace ID here for local development
-  // "projectName": "your-project-name", // Add your project name here for local development
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -30,5 +25,6 @@
         "zip_code": "0000"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/browser-use/pyproject.toml
+++ b/python-examples/browser-use/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "browser-use==0.11.2",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/bs4/Intuned.jsonc
+++ b/python-examples/bs4/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -25,4 +23,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/bs4/pyproject.toml
+++ b/python-examples/bs4/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "beautifulsoup4==4.14.3",
     "pydantic>=2.12.5",

--- a/python-examples/captcha-in-login/Intuned.jsonc
+++ b/python-examples/captcha-in-login/Intuned.jsonc
@@ -1,15 +1,12 @@
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API",
     "saveTraces": true
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "proxy": {
     "enabled": false
@@ -42,5 +39,6 @@
         "details_url_item": "https://scrapingcourse.com/ecommerce/product/mach-street-sweatshirt"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/captcha-in-login/pyproject.toml
+++ b/python-examples/captcha-in-login/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56.0",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/captcha-solving-basic/Intuned.jsonc
+++ b/python-examples/captcha-solving-basic/Intuned.jsonc
@@ -1,13 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "proxy": {
     "enabled": false
@@ -54,5 +52,6 @@
       "apiName": "captcha-solver",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/captcha-solving-basic/pyproject.toml
+++ b/python-examples/captcha-solving-basic/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/cdp-connection/Intuned.jsonc
+++ b/python-examples/cdp-connection/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  // "projectName": "your-project-name", // Add your project name here for local development
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -25,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/cdp-connection/pyproject.toml
+++ b/python-examples/cdp-connection/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "httpx==0.28.1",
     "pydantic>=2.0.0",

--- a/python-examples/computer-use/Intuned.jsonc
+++ b/python-examples/computer-use/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "proxy": {
     "enabled": false
@@ -26,5 +23,6 @@
         "query": "Go to https://books.toscrape.com, navigate to the Science Fiction category, and list the top 5 books"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/computer-use/pyproject.toml
+++ b/python-examples/computer-use/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",
     "python-dateutil~=2.9.0",

--- a/python-examples/crawl4ai/Intuned.jsonc
+++ b/python-examples/crawl4ai/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "large",
+    "maxCount": 1,
   },
   "proxy": {
     "enabled": false,
@@ -27,4 +24,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/crawl4ai/pyproject.toml
+++ b/python-examples/crawl4ai/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",
 ]

--- a/python-examples/e-commerce-auth-scrapingcourse/Intuned.jsonc
+++ b/python-examples/e-commerce-auth-scrapingcourse/Intuned.jsonc
@@ -1,14 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -20,5 +17,6 @@
       "apiName": "list",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-auth-scrapingcourse/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",
 ]

--- a/python-examples/e-commerce-nested/Intuned.jsonc
+++ b/python-examples/e-commerce-nested/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -24,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/e-commerce-nested/pyproject.toml
+++ b/python-examples/e-commerce-nested/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",
 ]

--- a/python-examples/e-commerce-scrapingcourse/Intuned.jsonc
+++ b/python-examples/e-commerce-scrapingcourse/Intuned.jsonc
@@ -1,13 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -19,5 +17,6 @@
       "apiName": "list",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/e-commerce-scrapingcourse/pyproject.toml
+++ b/python-examples/e-commerce-scrapingcourse/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic==2.10.6",
 ]

--- a/python-examples/e-commerce-shopify/Intuned.jsonc
+++ b/python-examples/e-commerce-shopify/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -25,4 +23,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/e-commerce-shopify/pyproject.toml
+++ b/python-examples/e-commerce-shopify/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/firecrawl/Intuned.jsonc
+++ b/python-examples/firecrawl/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "large",
+    "maxCount": 1,
   },
   "proxy": {
     "enabled": false,
@@ -35,4 +32,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/firecrawl/pyproject.toml
+++ b/python-examples/firecrawl/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",
     "pytz>=2024.1",

--- a/python-examples/hybrid-automation/Intuned.jsonc
+++ b/python-examples/hybrid-automation/Intuned.jsonc
@@ -1,17 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  // "workspaceId": "your-workspace-id", // Add your workspace ID here for local development
-  // "projectName": "your-project-name", // Add your project name here for local development
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -30,5 +26,6 @@
         "topic": "api-integration"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/hybrid-automation/pyproject.toml
+++ b/python-examples/hybrid-automation/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",
     "openai~=1.0",

--- a/python-examples/native-crawler/Intuned.jsonc
+++ b/python-examples/native-crawler/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "proxy": {
     "enabled": false
@@ -29,5 +26,6 @@
         "include_attachments": true
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/native-crawler/pyproject.toml
+++ b/python-examples/native-crawler/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/network-interception/Intuned.jsonc
+++ b/python-examples/network-interception/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -26,4 +24,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/network-interception/pyproject.toml
+++ b/python-examples/network-interception/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic>=2.12.5",
 ]

--- a/python-examples/playwright-basics/Intuned.jsonc
+++ b/python-examples/playwright-basics/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -24,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/playwright-basics/pyproject.toml
+++ b/python-examples/playwright-basics/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/quick-recipes/Intuned.jsonc
+++ b/python-examples/quick-recipes/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "proxy": {
     "enabled": false
@@ -24,5 +22,6 @@
       "apiName": "download-file",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/quick-recipes/pyproject.toml
+++ b/python-examples/quick-recipes/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/rpa-auth-example/Intuned.jsonc
+++ b/python-examples/rpa-auth-example/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -29,5 +26,6 @@
         "topic": "other"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/rpa-auth-example/pyproject.toml
+++ b/python-examples/rpa-auth-example/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
 ]

--- a/python-examples/rpa-example/Intuned.jsonc
+++ b/python-examples/rpa-example/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -28,5 +25,6 @@
         "topic": "other"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/rpa-example/pyproject.toml
+++ b/python-examples/rpa-example/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
 ]

--- a/python-examples/rpa-forms-example/Intuned.jsonc
+++ b/python-examples/rpa-forms-example/Intuned.jsonc
@@ -2,15 +2,12 @@
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
   "projectName": "insurance-form-filler",
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -63,5 +60,6 @@
         }
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/rpa-forms-example/pyproject.toml
+++ b/python-examples/rpa-forms-example/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "stagehand==3.5.0",
     "intuned-browser==0.1.17",
 ]

--- a/python-examples/scrapy/Intuned.jsonc
+++ b/python-examples/scrapy/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -24,5 +21,6 @@
         "max_pages": 10
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/scrapy/pyproject.toml
+++ b/python-examples/scrapy/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic>=2.10.6",
     "scrapy>=2.13.4",

--- a/python-examples/setup-hooks/Intuned.jsonc
+++ b/python-examples/setup-hooks/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -24,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/python-examples/setup-hooks/pyproject.toml
+++ b/python-examples/setup-hooks/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic>=2.0.0",
 ]

--- a/python-examples/stagehand/Intuned.jsonc
+++ b/python-examples/stagehand/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -26,5 +23,6 @@
         "category": "Travel"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/stagehand/pyproject.toml
+++ b/python-examples/stagehand/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",
     "python-dateutil~=2.9.0",

--- a/python-examples/starter-auth/Intuned.jsonc
+++ b/python-examples/starter-auth/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -22,5 +19,6 @@
       "apiName": "sample",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter-auth/pyproject.toml
+++ b/python-examples/starter-auth/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "pydantic[email]==2.10.6",
 ]

--- a/python-examples/starter-crawl4ai/Intuned.jsonc
+++ b/python-examples/starter-crawl4ai/Intuned.jsonc
@@ -1,14 +1,11 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
+    "maxCount": 1,
     "size": "large"
   },
   "metadata": {
@@ -27,5 +24,6 @@
         "url": "https://playwright.dev/docs/intro"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter-crawl4ai/pyproject.toml
+++ b/python-examples/starter-crawl4ai/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "crawl4ai==0.8.6",
 ]

--- a/python-examples/starter-network-interception/Intuned.jsonc
+++ b/python-examples/starter-network-interception/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -27,5 +25,6 @@
         "api_pattern": "/rest/v1/consultations"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter-network-interception/pyproject.toml
+++ b/python-examples/starter-network-interception/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/starter-rpa/Intuned.jsonc
+++ b/python-examples/starter-rpa/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -31,5 +28,6 @@
         "topic": "other"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter-rpa/pyproject.toml
+++ b/python-examples/starter-rpa/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/starter-scrapy/Intuned.jsonc
+++ b/python-examples/starter-scrapy/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -26,5 +24,6 @@
         "url": "https://quotes.toscrape.com/"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter-scrapy/pyproject.toml
+++ b/python-examples/starter-scrapy/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "scrapy>=2.13.4",
 ]

--- a/python-examples/starter-shopify/Intuned.jsonc
+++ b/python-examples/starter-shopify/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -23,5 +21,6 @@
         "product_url": "https://www.allbirds.com/products/womens-wool-runners-bough"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter-shopify/pyproject.toml
+++ b/python-examples/starter-shopify/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/python-examples/starter-stagehand/Intuned.jsonc
+++ b/python-examples/starter-stagehand/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -24,5 +22,6 @@
         "instruction": "Extract the first 5 books on the page. For each return title and price as detail."
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter-stagehand/pyproject.toml
+++ b/python-examples/starter-stagehand/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
     "anthropic~=0.75.0",
     "python-dateutil~=2.9.0",

--- a/python-examples/starter/Intuned.jsonc
+++ b/python-examples/starter/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -24,5 +22,6 @@
       "apiName": "sample",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/python-examples/starter/pyproject.toml
+++ b/python-examples/starter/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 dependencies = [
     "playwright==1.56",
-    "intuned-runtime==1.3.33",
+    "intuned-runtime==1.3.35",
     "intuned-browser==0.1.17",
 ]
 

--- a/typescript-examples/auth-with-email-otp/Intuned.jsonc
+++ b/typescript-examples/auth-with-email-otp/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -22,5 +19,6 @@
       "apiName": "list-contracts",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/auth-with-email-otp/package.json
+++ b/typescript-examples/auth-with-email-otp/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "resend": "^6.6.0",

--- a/typescript-examples/auth-with-secret-otp/Intuned.jsonc
+++ b/typescript-examples/auth-with-secret-otp/Intuned.jsonc
@@ -1,14 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -23,5 +20,6 @@
       "apiName": "list-contracts",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/auth-with-secret-otp/package.json
+++ b/typescript-examples/auth-with-secret-otp/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "otplib": "^12.0.1",
     "playwright": "~1.56.0",

--- a/typescript-examples/browser-sdk-showcase/Intuned.jsonc
+++ b/typescript-examples/browser-sdk-showcase/Intuned.jsonc
@@ -1,17 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  // "workspaceId": "your-workspace-id", // Add your workspace ID here for local development (required for AI helpers)
-  // "projectName": "your-project-name", // Add your project name here for local development (required for AI helpers)
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -27,4 +23,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/browser-sdk-showcase/package.json
+++ b/typescript-examples/browser-sdk-showcase/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/captcha-in-login/Intuned.jsonc
+++ b/typescript-examples/captcha-in-login/Intuned.jsonc
@@ -1,15 +1,12 @@
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API",
     "saveTraces": true
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "proxy": {
     "enabled": false
@@ -42,5 +39,6 @@
         "details_url_item": "https://scrapingcourse.com/ecommerce/product/mach-street-sweatshirt"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/captcha-in-login/package.json
+++ b/typescript-examples/captcha-in-login/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/captcha-solving-basic/Intuned.jsonc
+++ b/typescript-examples/captcha-solving-basic/Intuned.jsonc
@@ -1,13 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "proxy": {
     "enabled": false
@@ -54,5 +52,6 @@
       "apiName": "captcha-solver",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/captcha-solving-basic/package.json
+++ b/typescript-examples/captcha-solving-basic/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/cdp-connection/Intuned.jsonc
+++ b/typescript-examples/cdp-connection/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  // "projectName": "your-project-name", // Add your project name here for local development
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -25,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/cdp-connection/package.json
+++ b/typescript-examples/cdp-connection/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/computer-use/Intuned.jsonc
+++ b/typescript-examples/computer-use/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -24,5 +21,6 @@
       }
       
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/computer-use/package.json
+++ b/typescript-examples/computer-use/package.json
@@ -20,7 +20,7 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@browserbasehq/stagehand": "3.0.8",
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "luxon": "^3.7.2",
     "openai": "^6.10.0",

--- a/typescript-examples/e-commerce-auth-scrapingcourse/Intuned.jsonc
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/Intuned.jsonc
@@ -1,14 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -20,5 +17,6 @@
       "apiName": "list",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/e-commerce-auth-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/e-commerce-nested/Intuned.jsonc
+++ b/typescript-examples/e-commerce-nested/Intuned.jsonc
@@ -1,13 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -22,4 +20,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/e-commerce-nested/package.json
+++ b/typescript-examples/e-commerce-nested/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/e-commerce-scrapingcourse/Intuned.jsonc
+++ b/typescript-examples/e-commerce-scrapingcourse/Intuned.jsonc
@@ -1,13 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -21,5 +19,6 @@
         "limit": 10
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/e-commerce-scrapingcourse/package.json
+++ b/typescript-examples/e-commerce-scrapingcourse/package.json
@@ -11,7 +11,7 @@
     "license": "ISC",
     "dependencies": {
         "@intuned/browser": "0.1.16",
-        "@intuned/runtime": "1.3.29",
+        "@intuned/runtime": "1.3.31",
         "@types/node": "^20.10.3",
         "playwright": "~1.56.0",
         "zod": "^3.22.4"

--- a/typescript-examples/e-commerce-shopify/Intuned.jsonc
+++ b/typescript-examples/e-commerce-shopify/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -25,4 +23,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/e-commerce-shopify/package.json
+++ b/typescript-examples/e-commerce-shopify/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/hybrid-automation/Intuned.jsonc
+++ b/typescript-examples/hybrid-automation/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -29,5 +27,6 @@
       }
       
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/hybrid-automation/package.json
+++ b/typescript-examples/hybrid-automation/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@browserbasehq/stagehand": "3.0.8",
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "3.25.67"

--- a/typescript-examples/jsdom/Intuned.jsonc
+++ b/typescript-examples/jsdom/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -25,4 +23,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/jsdom/package.json
+++ b/typescript-examples/jsdom/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "jsdom": "^26.1.0",
     "playwright": "~1.56.0",

--- a/typescript-examples/native-crawler/Intuned.jsonc
+++ b/typescript-examples/native-crawler/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -25,5 +22,6 @@
         "max_pages": 5
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/native-crawler/package.json
+++ b/typescript-examples/native-crawler/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   },

--- a/typescript-examples/network-interception/Intuned.jsonc
+++ b/typescript-examples/network-interception/Intuned.jsonc
@@ -1,13 +1,11 @@
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -24,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/network-interception/package.json
+++ b/typescript-examples/network-interception/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/playwright-basics/Intuned.jsonc
+++ b/typescript-examples/playwright-basics/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -24,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/playwright-basics/package.json
+++ b/typescript-examples/playwright-basics/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/quick-recipes/Intuned.jsonc
+++ b/typescript-examples/quick-recipes/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -22,4 +20,5 @@
       "parameters": {},
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/quick-recipes/package.json
+++ b/typescript-examples/quick-recipes/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/rpa-auth-example/Intuned.jsonc
+++ b/typescript-examples/rpa-auth-example/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -29,5 +26,6 @@
         "topic": "web-scraping"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/rpa-auth-example/package.json
+++ b/typescript-examples/rpa-auth-example/package.json
@@ -17,7 +17,7 @@
     "license": "ISC",
     "dependencies": {
         "@intuned/browser": "0.1.16",
-        "@intuned/runtime": "1.3.29",
+        "@intuned/runtime": "1.3.31",
         "@types/node": "^20.10.3",
         "playwright": "~1.56.0",
         "zod": "^3.22.4"

--- a/typescript-examples/rpa-example/Intuned.jsonc
+++ b/typescript-examples/rpa-example/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -28,5 +25,6 @@
         "topic": "automation"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/rpa-example/package.json
+++ b/typescript-examples/rpa-example/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/rpa-forms-example/Intuned.jsonc
+++ b/typescript-examples/rpa-forms-example/Intuned.jsonc
@@ -2,15 +2,12 @@
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
   "projectName": "insurance-form-filler",
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -63,5 +60,6 @@
         }
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/rpa-forms-example/package.json
+++ b/typescript-examples/rpa-forms-example/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@browserbasehq/stagehand": "3.0.8",
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "3.25.67"

--- a/typescript-examples/setup-hooks/Intuned.jsonc
+++ b/typescript-examples/setup-hooks/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false,
-  },
   "authSessions": {
     "enabled": false,
   },
   "replication": {
-    "maxConcurrentRequests": 1,
     "size": "standard",
+    "maxCount": 1,
+    "minCount": 0,
   },
   "metadata": {
     "template": {
@@ -24,4 +22,5 @@
       },
     },
   },
+  "version": "2.0",
 }

--- a/typescript-examples/setup-hooks/package.json
+++ b/typescript-examples/setup-hooks/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/stagehand/Intuned.jsonc
+++ b/typescript-examples/stagehand/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -26,5 +23,6 @@
         "category": "Travel"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/stagehand/package.json
+++ b/typescript-examples/stagehand/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@browserbasehq/stagehand": "3.0.8",
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "3.25.67"

--- a/typescript-examples/starter-auth/Intuned.jsonc
+++ b/typescript-examples/starter-auth/Intuned.jsonc
@@ -1,16 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": true,
     "type": "API"
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -22,5 +19,6 @@
       "apiName": "sample",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/starter-auth/package.json
+++ b/typescript-examples/starter-auth/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "^3.22.4"

--- a/typescript-examples/starter-jsdom/Intuned.jsonc
+++ b/typescript-examples/starter-jsdom/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -26,5 +24,6 @@
         "url": "https://www.scrapingcourse.com/ecommerce/"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/starter-jsdom/package.json
+++ b/typescript-examples/starter-jsdom/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "jsdom": "^26.1.0",
     "playwright": "~1.56.0"

--- a/typescript-examples/starter-network-interception/Intuned.jsonc
+++ b/typescript-examples/starter-network-interception/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -27,5 +25,6 @@
         "apiPattern": "/rest/v1/consultations"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/starter-network-interception/package.json
+++ b/typescript-examples/starter-network-interception/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/starter-rpa/Intuned.jsonc
+++ b/typescript-examples/starter-rpa/Intuned.jsonc
@@ -1,15 +1,12 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": true
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1
   },
   "metadata": {
     "template": {
@@ -31,5 +28,6 @@
         "topic": "other"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/starter-rpa/package.json
+++ b/typescript-examples/starter-rpa/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/starter-shopify/Intuned.jsonc
+++ b/typescript-examples/starter-shopify/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -28,5 +26,6 @@
         "maxPages": 2
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/starter-shopify/package.json
+++ b/typescript-examples/starter-shopify/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }

--- a/typescript-examples/starter-stagehand/Intuned.jsonc
+++ b/typescript-examples/starter-stagehand/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -27,5 +25,6 @@
         "category": "Travel"
       }
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/starter-stagehand/package.json
+++ b/typescript-examples/starter-stagehand/package.json
@@ -13,7 +13,7 @@
     "@ai-sdk/openai": "^2.0.0",
     "@browserbasehq/stagehand": "3.0.8",
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0",
     "zod": "3.25.67"

--- a/typescript-examples/starter/Intuned.jsonc
+++ b/typescript-examples/starter/Intuned.jsonc
@@ -1,15 +1,13 @@
 // For more information, see our Intuned settings reference
 // https://intunedhq.com/docs/main/05-references/intuned-json
 {
-  "apiAccess": {
-    "enabled": false
-  },
   "authSessions": {
     "enabled": false
   },
   "replication": {
-    "maxConcurrentRequests": 1,
-    "size": "standard"
+    "size": "standard",
+    "maxCount": 1,
+    "minCount": 0
   },
   "metadata": {
     "template": {
@@ -24,5 +22,6 @@
       "apiName": "sample",
       "parameters": {}
     }
-  }
+  },
+  "version": "2.0"
 }

--- a/typescript-examples/starter/package.json
+++ b/typescript-examples/starter/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@intuned/browser": "0.1.16",
-    "@intuned/runtime": "1.3.29",
+    "@intuned/runtime": "1.3.31",
     "@types/node": "^20.10.3",
     "playwright": "~1.56.0"
   }


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [x] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [x] `testParameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Job scripts added to `package.json`/`pyproject.toml` if template is meant to run as a job (and for AuthSession if applicable)
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

