### PR TITLE
Add skipLibCheck to starter template tsconfigs

### DIFF
--- a/typescript-examples/network-interception/tsconfig.json
+++ b/typescript-examples/network-interception/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/starter-auth/tsconfig.json
+++ b/typescript-examples/starter-auth/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/starter/tsconfig.json
+++ b/typescript-examples/starter/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
## Problem

`@intuned/runtime`'s published `dist/runtime/export.d.ts` imports `@intuned/runtime-interface`, which is neither a dependency of the runtime package nor installable from a fresh project. As a result `npx tsc --noEmit` fails with TS2307 on every new TypeScript project scaffolded from `starter`, `starter-auth`, or `network-interception` — before the user (or an agent) has written a single line.

In practice each consumer improvises a different workaround: hand-written `types/runtime-interface.d.ts` stubs with `unknown` fields, ad hoc dependency additions, or tsconfig tweaks.

## Fix

Add `"skipLibCheck": true` to the three template tsconfigs. This skips type-checking of `node_modules` declaration files while keeping the project's own source fully type-checked. Four other examples in this repo (`computer-use`, `hybrid-automation`, `rpa-forms-example`, `stagehand`) already set it, which is why they don't exhibit the failure.

The root cause (the runtime package leaking an unresolvable type import) still deserves a fix in the runtime SDK; this PR just stops it from breaking every fresh project in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)