### PR TITLE
Add skipLibCheck to remaining TypeScript template tsconfigs

### DIFF
--- a/typescript-examples/auth-with-email-otp/tsconfig.json
+++ b/typescript-examples/auth-with-email-otp/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/auth-with-secret-otp/tsconfig.json
+++ b/typescript-examples/auth-with-secret-otp/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/browser-sdk-showcase/tsconfig.json
+++ b/typescript-examples/browser-sdk-showcase/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/captcha-in-login/tsconfig.json
+++ b/typescript-examples/captcha-in-login/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/captcha-solving-basic/tsconfig.json
+++ b/typescript-examples/captcha-solving-basic/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/cdp-connection/tsconfig.json
+++ b/typescript-examples/cdp-connection/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/typescript-examples/e-commerce-auth-scrapingcourse/tsconfig.json
+++ b/typescript-examples/e-commerce-auth-scrapingcourse/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/e-commerce-nested/tsconfig.json
+++ b/typescript-examples/e-commerce-nested/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/e-commerce-scrapingcourse/tsconfig.json
+++ b/typescript-examples/e-commerce-scrapingcourse/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/e-commerce-shopify/tsconfig.json
+++ b/typescript-examples/e-commerce-shopify/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/jsdom/tsconfig.json
+++ b/typescript-examples/jsdom/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/native-crawler/tsconfig.json
+++ b/typescript-examples/native-crawler/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/playwright-basics/tsconfig.json
+++ b/typescript-examples/playwright-basics/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/quick-recipes/tsconfig.json
+++ b/typescript-examples/quick-recipes/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/rpa-auth-example/tsconfig.json
+++ b/typescript-examples/rpa-auth-example/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/rpa-example/tsconfig.json
+++ b/typescript-examples/rpa-example/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/setup-hooks/tsconfig.json
+++ b/typescript-examples/setup-hooks/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/starter-jsdom/tsconfig.json
+++ b/typescript-examples/starter-jsdom/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/starter-network-interception/tsconfig.json
+++ b/typescript-examples/starter-network-interception/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/starter-rpa/tsconfig.json
+++ b/typescript-examples/starter-rpa/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"

--- a/typescript-examples/starter-shopify/tsconfig.json
+++ b/typescript-examples/starter-shopify/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "sourceMap": false,
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
Follow-up to #293, which added `skipLibCheck` to only `starter`, `starter-auth`, and `network-interception`. The same TS2307 failure — `@intuned/runtime`'s published `.d.ts` imports the non-installable `@intuned/runtime-interface`, so `tsc --noEmit` fails on any project scaffolded from these templates — still affects every other TypeScript example. This adds `"skipLibCheck": true` to the remaining 21 tsconfigs, matching the setting `computer-use`, `hybrid-automation`, `rpa-forms-example`, and `stagehand` already use. No template code, structure, or READMEs change.

# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language) — N/A, config-only change to existing TS templates
- [x] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable — unchanged
- [x] `.parameters/` directory exists for each API (and AuthSession if applicable) — unchanged
- [x] Jobs and Auth Sessions added to `intuned-resources` if applicable — unchanged
- [x] README written following existing example structure — no README changes needed
- [x] Main README and language-specific README updated if adding/modifying examples — N/A, no examples added/removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)