### PR TITLE
clean up auth session from starter auth templates

### DIFF
--- a/python-examples/starter-auth/auth-sessions-instances/test-authsession/auth-session.json
+++ b/python-examples/starter-auth/auth-sessions-instances/test-authsession/auth-session.json
@@ -1,20 +1,5 @@
 {
   "cookies": [],
-  "origins": [
-    {
-      "origin": "https://sandbox.intuned.dev",
-      "localStorage": [
-        {
-          "name": "sb-pfaqkmnqacbiimndjwyp-auth-token",
-          "value": "{\"access_token\":\"eyJhbGciOiJIUzI1NiIsImtpZCI6IjVTcjdyazhEa1BKNExCbWciLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3BmYXFrbW5xYWNiaWltbmRqd3lwLnN1cGFiYXNlLmNvL2F1dGgvdjEiLCJzdWIiOiI4OTZjYWUwYy03Yjk3LTQyYjEtYTRjYy00NTU5OTJlNDQ0MGUiLCJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoxNzY2MDY0NjEyLCJpYXQiOjE3NjYwNjEwMTIsImVtYWlsIjoiZGVtb0BlbWFpbC5jb20iLCJwaG9uZSI6IiIsImFwcF9tZXRhZGF0YSI6eyJwcm92aWRlciI6ImVtYWlsIiwicHJvdmlkZXJzIjpbImVtYWlsIl19LCJ1c2VyX21ldGFkYXRhIjp7ImVtYWlsX3ZlcmlmaWVkIjp0cnVlfSwicm9sZSI6ImF1dGhlbnRpY2F0ZWQiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTc2NjA2MTAxMn1dLCJzZXNzaW9uX2lkIjoiMTUzYWQ1NzYtMDM1OS00MTE3LTg1MGMtMDViN2ViZDFkY2MxIiwiaXNfYW5vbnltb3VzIjpmYWxzZX0.GZ4i_66Ah27BKV1JWNc_fjGe76fN6sVJjYeA4T9gBYU\",\"token_type\":\"bearer\",\"expires_in\":3600,\"expires_at\":1766064612,\"refresh_token\":\"7b743pzohjl6\",\"user\":{\"id\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\",\"aud\":\"authenticated\",\"role\":\"authenticated\",\"email\":\"demo@email.com\",\"email_confirmed_at\":\"2025-11-10T23:56:02.00755Z\",\"phone\":\"\",\"confirmed_at\":\"2025-11-10T23:56:02.00755Z\",\"last_sign_in_at\":\"2025-12-18T12:30:12.856087215Z\",\"app_metadata\":{\"provider\":\"email\",\"providers\":[\"email\"]},\"user_metadata\":{\"email_verified\":true},\"identities\":[{\"identity_id\":\"6041d4c7-22df-4aae-9c18-f2bb3c79e41a\",\"id\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\",\"user_id\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\",\"identity_data\":{\"email\":\"demo@email.com\",\"email_verified\":false,\"phone_verified\":false,\"sub\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\"},\"provider\":\"email\",\"last_sign_in_at\":\"2025-11-10T23:56:01.997364Z\",\"created_at\":\"2025-11-10T23:56:01.998058Z\",\"updated_at\":\"2025-11-10T23:56:01.998058Z\",\"email\":\"demo@email.com\"}],\"created_at\":\"2025-11-10T23:56:01.972446Z\",\"updated_at\":\"2025-12-18T12:30:12.85942Z\",\"is_anonymous\":false},\"weak_password\":null}"
-        }
-      ]
-    }
-  ],
-  "sessionStorage": [
-    {
-      "origin": "https://sandbox.intuned.dev",
-      "sessionStorage": []
-    }
-  ]
+  "origins": [],
+  "sessionStorage": []
 }

--- a/typescript-examples/starter-auth/auth-sessions-instances/test-authsession/auth-session.json
+++ b/typescript-examples/starter-auth/auth-sessions-instances/test-authsession/auth-session.json
@@ -1,20 +1,5 @@
 {
   "cookies": [],
-  "origins": [
-    {
-      "origin": "https://sandbox.intuned.dev",
-      "localStorage": [
-        {
-          "name": "sb-pfaqkmnqacbiimndjwyp-auth-token",
-          "value": "{\"access_token\":\"eyJhbGciOiJIUzI1NiIsImtpZCI6IjVTcjdyazhEa1BKNExCbWciLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3BmYXFrbW5xYWNiaWltbmRqd3lwLnN1cGFiYXNlLmNvL2F1dGgvdjEiLCJzdWIiOiI4OTZjYWUwYy03Yjk3LTQyYjEtYTRjYy00NTU5OTJlNDQ0MGUiLCJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoxNzc2MDczMjA0LCJpYXQiOjE3NzYwNjk2MDQsImVtYWlsIjoiZGVtb0BlbWFpbC5jb20iLCJwaG9uZSI6IiIsImFwcF9tZXRhZGF0YSI6eyJwcm92aWRlciI6ImVtYWlsIiwicHJvdmlkZXJzIjpbImVtYWlsIl19LCJ1c2VyX21ldGFkYXRhIjp7ImVtYWlsX3ZlcmlmaWVkIjp0cnVlfSwicm9sZSI6ImF1dGhlbnRpY2F0ZWQiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTc3NjA2OTYwNH1dLCJzZXNzaW9uX2lkIjoiNDIxNGVlZGQtNTkxNS00NmJlLTg1YmItMGQ3NWNkZjdmNmUxIiwiaXNfYW5vbnltb3VzIjpmYWxzZX0.jdHce-_vY95eHfLNM4E_p8zbvdEvzV6IzE3Y7XH3P6Y\",\"token_type\":\"bearer\",\"expires_in\":3600,\"expires_at\":1776073204,\"refresh_token\":\"rrwlxu3ffemm\",\"user\":{\"id\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\",\"aud\":\"authenticated\",\"role\":\"authenticated\",\"email\":\"demo@email.com\",\"email_confirmed_at\":\"2025-11-10T23:56:02.00755Z\",\"phone\":\"\",\"confirmed_at\":\"2025-11-10T23:56:02.00755Z\",\"last_sign_in_at\":\"2026-04-13T08:40:04.532105632Z\",\"app_metadata\":{\"provider\":\"email\",\"providers\":[\"email\"]},\"user_metadata\":{\"email_verified\":true},\"identities\":[{\"identity_id\":\"6041d4c7-22df-4aae-9c18-f2bb3c79e41a\",\"id\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\",\"user_id\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\",\"identity_data\":{\"email\":\"demo@email.com\",\"email_verified\":false,\"phone_verified\":false,\"sub\":\"896cae0c-7b97-42b1-a4cc-455992e4440e\"},\"provider\":\"email\",\"last_sign_in_at\":\"2025-11-10T23:56:01.997364Z\",\"created_at\":\"2025-11-10T23:56:01.998058Z\",\"updated_at\":\"2025-11-10T23:56:01.998058Z\",\"email\":\"demo@email.com\"}],\"created_at\":\"2025-11-10T23:56:01.972446Z\",\"updated_at\":\"2026-04-13T08:40:04.535676Z\",\"is_anonymous\":false},\"weak_password\":null}"
-        }
-      ]
-    }
-  ],
-  "sessionStorage": [
-    {
-      "origin": "https://sandbox.intuned.dev",
-      "sessionStorage": []
-    }
-  ]
+  "origins": [],
+  "sessionStorage": []
 }


### PR DESCRIPTION
# Template PR Checklist

- [x] Template exists in both TypeScript and Python (or noted why only one language)
- [ ] Uses `@intuned/browser` (TypeScript) or `intuned_browser` (Python) helpers where applicable
- [ ] `.parameters/` directory exists for each API (and AuthSession if applicable)
- [ ] Jobs and Auth Sessions added to `intuned-resources` if applicable.
- [ ] README written following existing example structure (similar to `rpa-auth-example/README.md` or `quick-recipes/README.md`)
- [ ] Main README and language-specific README updated if adding/modifying examples

