### PR TITLE
Attach crawl4ai to Intuned's browser over CDP instead of launching a new one

### DIFF
--- a/python-examples/crawl4ai/README.md
+++ b/python-examples/crawl4ai/README.md
@@ -88,6 +88,8 @@ intuned dev deploy
 │   └── adaptive-crawl/
 │       ├── statistical.py            # Statistical adaptive crawl
 │       └── embedding.py              # Embedding adaptive crawl
+├── hooks/
+│   └── setup_context.py              # Stores the CDP URL of Intuned's browser
 ├── intuned-resources/
 │   └── jobs/
 │       ├── simple-crawl.job.jsonc

--- a/python-examples/crawl4ai/api/adaptive-crawl/embedding.py
+++ b/python-examples/crawl4ai/api/adaptive-crawl/embedding.py
@@ -8,10 +8,11 @@ Based on: https://docs.crawl4ai.com/core/adaptive-crawling/
 
 from typing import TypedDict
 
-from intuned_runtime import get_ai_gateway_config
+from intuned_runtime import attempt_store, get_ai_gateway_config
 from playwright.async_api import BrowserContext, Page
 
 from crawl4ai import AdaptiveConfig, AdaptiveCrawler, AsyncWebCrawler, LLMConfig
+from crawl4ai.async_configs import BrowserConfig
 
 
 class Params(TypedDict, total=False):
@@ -59,7 +60,12 @@ async def automation(
         top_k_links=3,
     )
 
-    async with AsyncWebCrawler() as crawler:
+    # Attach to Intuned's running browser instead of launching a new one
+    browser_config = BrowserConfig(
+        browser_mode="custom", cdp_url=attempt_store.get("cdp_url")
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
         adaptive = AdaptiveCrawler(crawler, config=config)
 
         await adaptive.digest(

--- a/python-examples/crawl4ai/api/adaptive-crawl/statistical.py
+++ b/python-examples/crawl4ai/api/adaptive-crawl/statistical.py
@@ -6,9 +6,11 @@ Based on: https://docs.crawl4ai.com/core/adaptive-crawling/
 
 from typing import TypedDict
 
+from intuned_runtime import attempt_store
 from playwright.async_api import BrowserContext, Page
 
 from crawl4ai import AdaptiveConfig, AdaptiveCrawler, AsyncWebCrawler
+from crawl4ai.async_configs import BrowserConfig
 
 
 class Params(TypedDict, total=False):
@@ -42,7 +44,12 @@ async def automation(
         top_k_links=3,
     )
 
-    async with AsyncWebCrawler() as crawler:
+    # Attach to Intuned's running browser instead of launching a new one
+    browser_config = BrowserConfig(
+        browser_mode="custom", cdp_url=attempt_store.get("cdp_url")
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
         adaptive = AdaptiveCrawler(crawler, config=config)
 
         await adaptive.digest(

--- a/python-examples/crawl4ai/api/content-selection/css-based.py
+++ b/python-examples/crawl4ai/api/content-selection/css-based.py
@@ -9,6 +9,7 @@ Based on: https://docs.crawl4ai.com/core/content-selection/
 import json
 from typing import Any, TypedDict
 
+from intuned_runtime import attempt_store
 from playwright.async_api import BrowserContext, Page
 
 from crawl4ai import (
@@ -17,6 +18,7 @@ from crawl4ai import (
     CrawlerRunConfig,
     JsonCssExtractionStrategy,
 )
+from crawl4ai.async_configs import BrowserConfig
 
 
 class Params(TypedDict, total=False):
@@ -60,7 +62,12 @@ async def automation(
         verbose=True,
     )
 
-    async with AsyncWebCrawler() as crawler:
+    # Attach to Intuned's running browser instead of launching a new one
+    browser_config = BrowserConfig(
+        browser_mode="custom", cdp_url=attempt_store.get("cdp_url")
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
         result = await crawler.arun(url=url, config=config)
 
         if not result.success:

--- a/python-examples/crawl4ai/api/content-selection/llm-based.py
+++ b/python-examples/crawl4ai/api/content-selection/llm-based.py
@@ -9,11 +9,12 @@ Based on: https://docs.crawl4ai.com/core/content-selection/
 import json
 from typing import TypedDict
 
-from intuned_runtime import get_ai_gateway_config
+from intuned_runtime import attempt_store, get_ai_gateway_config
 from playwright.async_api import BrowserContext, Page
 from pydantic import BaseModel
 
 from crawl4ai import AsyncWebCrawler, CrawlerRunConfig, LLMConfig, LLMExtractionStrategy
+from crawl4ai.async_configs import BrowserConfig
 
 
 class ArticleData(BaseModel):
@@ -54,7 +55,12 @@ async def automation(
         extraction_strategy=llm_strategy,
     )
 
-    async with AsyncWebCrawler() as crawler:
+    # Attach to Intuned's running browser instead of launching a new one
+    browser_config = BrowserConfig(
+        browser_mode="custom", cdp_url=attempt_store.get("cdp_url")
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
         result = await crawler.arun(url=url, config=config)
 
         if not result.success:

--- a/python-examples/crawl4ai/api/deep-crawl.py
+++ b/python-examples/crawl4ai/api/deep-crawl.py
@@ -9,6 +9,7 @@ Based on: https://docs.crawl4ai.com/core/deep-crawling/
 import logging
 from typing import Literal, TypedDict
 
+from intuned_runtime import attempt_store
 from playwright.async_api import BrowserContext, Page
 
 from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
@@ -107,7 +108,11 @@ async def automation(
             url_scorer=url_scorer,
         )
 
-    browser_config = BrowserConfig(verbose=False)
+    # Attach to Intuned's running browser instead of launching a new one
+    cdp_url = attempt_store.get("cdp_url")
+    browser_config = BrowserConfig(
+        browser_mode="custom", cdp_url=cdp_url, verbose=False
+    )
     run_config = CrawlerRunConfig(
         deep_crawl_strategy=strategy,
         scraping_strategy=LXMLWebScrapingStrategy(),

--- a/python-examples/crawl4ai/api/multi-crawl.py
+++ b/python-examples/crawl4ai/api/multi-crawl.py
@@ -8,6 +8,7 @@ Based on: https://docs.crawl4ai.com/advanced/multi-url-crawling/
 
 from typing import Literal, TypedDict
 
+from intuned_runtime import attempt_store
 from playwright.async_api import BrowserContext, Page
 
 from crawl4ai import AsyncWebCrawler, CacheMode, CrawlerRunConfig
@@ -57,7 +58,9 @@ async def automation(
             rate_limiter=rate_limiter,
         )
 
-    browser_config = BrowserConfig(headless=True, verbose=True)
+    # Attach to Intuned's running browser instead of launching a new one
+    cdp_url = attempt_store.get("cdp_url")
+    browser_config = BrowserConfig(browser_mode="custom", cdp_url=cdp_url, verbose=True)
     run_config = CrawlerRunConfig(
         cache_mode=CacheMode.BYPASS,
         verbose=True,

--- a/python-examples/crawl4ai/api/simple-crawl.py
+++ b/python-examples/crawl4ai/api/simple-crawl.py
@@ -6,6 +6,7 @@ Based on: https://docs.crawl4ai.com/core/simple-crawling/
 
 from typing import TypedDict
 
+from intuned_runtime import attempt_store
 from playwright.async_api import BrowserContext, Page
 
 from crawl4ai import AsyncWebCrawler
@@ -29,7 +30,9 @@ async def automation(
             "error": "URL parameter is required",
         }
 
-    browser_config = BrowserConfig(verbose=True)
+    # Attach to Intuned's running browser instead of launching a new one
+    cdp_url = attempt_store.get("cdp_url")
+    browser_config = BrowserConfig(browser_mode="custom", cdp_url=cdp_url, verbose=True)
     run_config = CrawlerRunConfig(
         # Content filtering
         word_count_threshold=10,

--- a/python-examples/crawl4ai/hooks/setup_context.py
+++ b/python-examples/crawl4ai/hooks/setup_context.py
@@ -1,0 +1,5 @@
+from intuned_runtime import attempt_store
+
+
+async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
+    attempt_store.set("cdp_url", cdp_url)

--- a/python-examples/firecrawl/README.md
+++ b/python-examples/firecrawl/README.md
@@ -239,6 +239,8 @@ intuned dev deploy
 │   ├── map.py                # Extract all links from a page
 │   ├── crawl.py              # Deep crawl multiple pages
 │   └── search.py             # Web search with full content
+├── hooks/
+│   └── setup_context.py      # Stores the CDP URL of Intuned's browser
 ├── intuned-resources/
 │   └── jobs/
 │       ├── scrape.job.jsonc

--- a/python-examples/firecrawl/hooks/setup_context.py
+++ b/python-examples/firecrawl/hooks/setup_context.py
@@ -1,0 +1,5 @@
+from intuned_runtime import attempt_store
+
+
+async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
+    attempt_store.set("cdp_url", cdp_url)

--- a/python-examples/firecrawl/utils/browser.py
+++ b/python-examples/firecrawl/utils/browser.py
@@ -1,3 +1,5 @@
+from intuned_runtime import attempt_store
+
 from crawl4ai.async_configs import BrowserConfig
 
 # Mobile Chrome user agent
@@ -21,6 +23,9 @@ def create_browser_config(
     viewport = MOBILE_VIEWPORT if mobile else DESKTOP_VIEWPORT
 
     config_kwargs = {
+        # Attach to Intuned's running browser instead of launching a new one
+        "browser_mode": "custom",
+        "cdp_url": attempt_store.get("cdp_url"),
         "headless": headless,
         "viewport_width": viewport[0],
         "viewport_height": viewport[1],

--- a/python-examples/starter-crawl4ai/README.md
+++ b/python-examples/starter-crawl4ai/README.md
@@ -56,6 +56,8 @@ intuned dev deploy
 starter-crawl4ai/
 ├── api/
 │   └── simple-crawl.py                # Crawl a single URL to markdown
+├── hooks/
+│   └── setup_context.py               # Stores the CDP URL of Intuned's browser
 ├── intuned-resources/
 │   └── jobs/
 │       └── simple-crawl.job.jsonc     # Job definition for simple-crawl API

--- a/python-examples/starter-crawl4ai/api/simple-crawl.py
+++ b/python-examples/starter-crawl4ai/api/simple-crawl.py
@@ -6,6 +6,7 @@ Based on: https://docs.crawl4ai.com/core/simple-crawling/
 
 from typing import TypedDict
 
+from intuned_runtime import attempt_store
 from playwright.async_api import BrowserContext, Page
 
 from crawl4ai import AsyncWebCrawler
@@ -29,7 +30,9 @@ async def automation(
             "error": "URL parameter is required",
         }
 
-    browser_config = BrowserConfig(verbose=True)
+    # Attach to Intuned's running browser instead of launching a new one
+    cdp_url = attempt_store.get("cdp_url")
+    browser_config = BrowserConfig(browser_mode="custom", cdp_url=cdp_url, verbose=True)
     run_config = CrawlerRunConfig(
         # Content filtering
         word_count_threshold=10,

--- a/python-examples/starter-crawl4ai/hooks/setup_context.py
+++ b/python-examples/starter-crawl4ai/hooks/setup_context.py
@@ -1,0 +1,5 @@
+from intuned_runtime import attempt_store
+
+
+async def setup_context(*, api_name: str, api_parameters: str, cdp_url: str):
+    attempt_store.set("cdp_url", cdp_url)


### PR DESCRIPTION
## Problem

The three crawl4ai-based Python examples (`starter-crawl4ai`, `crawl4ai`, `firecrawl` — which uses crawl4ai under the hood) built `BrowserConfig` in dedicated mode, so every run launched its **own fresh vanilla Chromium** instead of using Intuned's running browser. That:

- bypasses the stealth browser entirely (fingerprint profile, proxy, auth session),
- fails outright on authoring machines: crawl4ai's Playwright (1.61 → chromium build 1228) doesn't match the pre-installed browser build, producing `Executable doesn't exist: /vol/playwright-browsers/chromium-1228/chrome-linux64/chrome`.

Every other browser-adjacent example (stagehand, browser-use, computer-use, cdp-connection, …) already attaches over CDP; these were the only three that launched their own browser.

## Fix

- Add `hooks/setup_context.py` to each project storing the runtime's `cdp_url` in the attempt store (same pattern as `starter-stagehand`).
- Every crawl4ai launch site now passes `browser_mode="custom"` + `cdp_url`, so `AsyncWebCrawler` attaches to the existing Intuned browser via `connect_over_cdp` — no local Chromium executable needed.
- `firecrawl` only needed the shared `utils/browser.py` changed; `crawl4ai` needed all 7 API files; `starter-crawl4ai` its single API.
- If `cdp_url` is absent, crawl4ai falls back to its previous dedicated launch, so the examples still run outside Intuned.
- READMEs: added `hooks/` to the project-structure trees.

## Testing

Cloned each project, `uv sync`, and ran against a local `intuned dev browser` with `intuned dev run`:

| Project | APIs run | Result |
|---|---|---|
| starter-crawl4ai | simple-crawl | ✅ markdown extracted |
| crawl4ai | simple-crawl, deep-crawl, multi-crawl (3 URLs), adaptive-crawl/statistical, content-selection/css-based | ✅ all |
| firecrawl | scrape, map, crawl | ✅ all |

Confirmed genuine CDP attachment (not a silent dedicated-launch fallback): crawl4ai's `[BROWSER] WebSocket CDP URL provided` debug line only prints on the connect-over-CDP path.

The two AI-gateway-dependent APIs (`content-selection/llm-based`, adaptive embedding) share the exact same browser code path; they were only untestable locally for lack of a workspace ID at `get_ai_gateway_config()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AuiorRD7vyGTDzBHbKjKf